### PR TITLE
Add support for spigot components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,13 @@
         </plugins>
     </build>
 
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.jetbrains</groupId>
@@ -123,6 +130,15 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.10</version>
+        </dependency>
+
+        <!-- optional dependency to allow spigot parsing -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.19.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/src/main/java/de/turtle_exception/fancyformat/Buffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/Buffer.java
@@ -22,7 +22,7 @@ public abstract class Buffer<T> {
     public abstract @NotNull List<Node> parse();
 
     protected @NotNull List<Node> asText() {
-        return List.of(new TextNode(parent, format.getMutatorObjectToString().apply(raw)));
+        return List.of(new TextNode(parent, format.makeString(raw)));
     }
 
     protected @NotNull Gson getGson() {

--- a/src/main/java/de/turtle_exception/fancyformat/Buffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/Buffer.java
@@ -6,19 +6,23 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public abstract class Buffer {
+public abstract class Buffer<T> {
     protected @NotNull Node parent;
-    protected @NotNull String raw;
+    protected @NotNull T raw;
 
-    protected Buffer(@NotNull Node parent, @NotNull String raw) {
+    private final @NotNull Format<T> format;
+
+    protected Buffer(@NotNull Node parent, @NotNull T raw, @NotNull Format<T> format) {
         this.parent = parent;
         this.raw = raw;
+
+        this.format = format;
     }
 
     public abstract @NotNull List<Node> parse();
 
     protected @NotNull List<Node> asText() {
-        return List.of(new TextNode(parent, raw));
+        return List.of(new TextNode(parent, format.getMutatorObjectToString().apply(raw)));
     }
 
     protected @NotNull Gson getGson() {

--- a/src/main/java/de/turtle_exception/fancyformat/FancyFormatter.java
+++ b/src/main/java/de/turtle_exception/fancyformat/FancyFormatter.java
@@ -47,8 +47,12 @@ public class FancyFormatter {
      * @param format The initial format of {@code content}.
      * @return A {@link FormatText} instance representing the provided message.
      */
-    public @NotNull FormatText newText(@NotNull String content, @NotNull Format<?> format) {
-        return new FormatText(this, content, format);
+    public <T> @NotNull FormatText<T> newText(@NotNull T content, @NotNull Format<T> format) {
+        return new FormatText<>(this, content, format);
+    }
+
+    public @NotNull FormatText<String> newText(@NotNull String content, @NotNull Format<String> format) {
+        return new FormatText<>(this, content, format);
     }
 
     /**
@@ -61,10 +65,17 @@ public class FancyFormatter {
      * @param nativeText Native representation of a message.
      * @return A {@link FormatText} instance representing the provided message.
      */
-    public @NotNull FormatText ofNative(@NotNull String nativeText) {
-        for (Format<?> value : Format.values())
-            if (nativeText.startsWith(value.getCode() + "#"))
-                return this.newText(nativeText.substring((value.getCode() + "#").length()), value);
+    @SuppressWarnings("unchecked")
+    public @NotNull FormatText<String> ofNative(@NotNull String nativeText) throws IllegalArgumentException {
+        for (Format<?> value : Format.values()) {
+            if (nativeText.startsWith(value.getCode() + "#")) {
+                try {
+                    return this.newText(nativeText.substring((value.getCode() + "#").length()), (Format<String>) value);
+                } catch (ClassCastException e) {
+                    throw new IllegalArgumentException(value.getName() + " does not support native text.");
+                }
+            }
+        }
         return this.newText(nativeText, Format.PLAINTEXT);
     }
 

--- a/src/main/java/de/turtle_exception/fancyformat/FancyFormatter.java
+++ b/src/main/java/de/turtle_exception/fancyformat/FancyFormatter.java
@@ -47,7 +47,7 @@ public class FancyFormatter {
      * @param format The initial format of {@code content}.
      * @return A {@link FormatText} instance representing the provided message.
      */
-    public @NotNull FormatText newText(@NotNull String content, @NotNull Format format) {
+    public @NotNull FormatText newText(@NotNull String content, @NotNull Format<?> format) {
         return new FormatText(this, content, format);
     }
 
@@ -62,7 +62,7 @@ public class FancyFormatter {
      * @return A {@link FormatText} instance representing the provided message.
      */
     public @NotNull FormatText ofNative(@NotNull String nativeText) {
-        for (Format value : Format.values())
+        for (Format<?> value : Format.values())
             if (nativeText.startsWith(value.getCode() + "#"))
                 return this.newText(nativeText.substring((value.getCode() + "#").length()), value);
         return this.newText(nativeText, Format.PLAINTEXT);

--- a/src/main/java/de/turtle_exception/fancyformat/Format.java
+++ b/src/main/java/de/turtle_exception/fancyformat/Format.java
@@ -3,6 +3,8 @@ package de.turtle_exception.fancyformat;
 import com.google.gson.JsonElement;
 import de.turtle_exception.fancyformat.buffers.*;
 import de.turtle_exception.fancyformat.builders.*;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.BiFunction;
@@ -11,7 +13,7 @@ import java.util.function.Function;
 /** Each value of this enum represents a specific text format that is supported by this library. */
 public final class Format<T> {
     /** Raw text that does not have any style or feature. */
-    public static final Format<String> PLAINTEXT = new Format<String>("PLAINTEXT", 0,
+    public static final Format<String> PLAINTEXT = new Format<>("PLAINTEXT", 0,
             PlaintextBuffer::new,
             node -> new PlaintextBuilder(node).build(),
             s -> s);
@@ -24,7 +26,7 @@ public final class Format<T> {
      * Discord Markdown format as specified by
      * <a href="https://support.discord.com/hc/en-us/articles/210298617">Discord Support: Markdown Text 101</a>.
      */
-    public static final Format<String> DISCORD = new Format<String>("DISCORD", 2,
+    public static final Format<String> DISCORD = new Format<>("DISCORD", 2,
             DiscordBuffer::new,
             node -> new DiscordBuilder(node).build(),
             s -> s);
@@ -40,16 +42,20 @@ public final class Format<T> {
      * Minecraft legacy formatting codes as specified by
      * <a href="https://minecraft.fandom.com/wiki/Formatting_codes">Minecraft Wiki: Formatting codes</a>.
      */
-    public static final Format<String> MINECRAFT_LEGACY = new Format<String>("MINECRAFT_LEGACY", 4,
+    public static final Format<String> MINECRAFT_LEGACY = new Format<>("MINECRAFT_LEGACY", 4,
             MinecraftLegacyBuffer::new,
             node -> new MinecraftLegacyBuilder(node).build(),
             s -> s);
+    public static final Format<BaseComponent[]> SPIGOT_COMPONENTS = new Format<>("SPIGOT_FORMAT", 5,
+            SpigotComponentsBuffer::new,
+            node -> new SpigotComponentsBuilder(node).build(),
+            components -> new TextComponent(components).toLegacyText());
 
     private final String name;
     private final int code;
     private final BiFunction<Node, T, Buffer<T>> mutatorStringToNode;
-    private final   Function<Node, T>              mutatorNodeToObject;
-    private final   Function<T   , String>         mutatorObjectToString;
+    private final   Function<Node, T>            mutatorNodeToObject;
+    private final   Function<T   , String>       mutatorObjectToString;
 
     private Format(@NotNull String name, int code, BiFunction<Node, T, Buffer<T>> mutatorStringToNode, Function<Node, T> mutatorNodeToObject, Function<T, String> mutatorObjectToString) {
         this.name = name;

--- a/src/main/java/de/turtle_exception/fancyformat/Format.java
+++ b/src/main/java/de/turtle_exception/fancyformat/Format.java
@@ -1,5 +1,6 @@
 package de.turtle_exception.fancyformat;
 
+import com.google.gson.JsonElement;
 import de.turtle_exception.fancyformat.buffers.*;
 import de.turtle_exception.fancyformat.builders.*;
 import org.jetbrains.annotations.NotNull;
@@ -8,45 +9,52 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /** Each value of this enum represents a specific text format that is supported by this library. */
-public enum Format {
+public final class Format<T> {
     /** Raw text that does not have any style or feature. */
-    PLAINTEXT(0,
+    public static final Format<String> PLAINTEXT = new Format<>(0,
             PlaintextBuffer::new,
-            node -> new PlaintextBuilder(node).build()),
+            node -> new PlaintextBuilder(node).build(),
+            s -> s);
     /** A universal format that preserves every feature or style of every other format. */
-    TURTLE(1,
+    public static final Format<JsonElement> TURTLE = new Format<>(1,
             TurtleBuffer::new,
-            node -> new TurtleBuilder(node).build()),
+            node -> new TurtleBuilder(node).build(),
+            JsonElement::toString);
     /**
      * Discord Markdown format as specified by
      * <a href="https://support.discord.com/hc/en-us/articles/210298617">Discord Support: Markdown Text 101</a>.
      */
-    DISCORD(2,
+    public static final Format<String> DISCORD = new Format<>(2,
             DiscordBuffer::new,
-            node -> new DiscordBuilder(node).build()),
+            node -> new DiscordBuilder(node).build(),
+            s -> s);
     /**
      * Minecraft JSON format as specified by
      * <a href="https://minecraft.fandom.com/wiki/Raw_JSON_text_format">Minecraft Wiki: Raw JSON text format</a>.
      */
-    MINECRAFT_JSON(3,
+    public static final Format<JsonElement> MINECRAFT_JSON = new Format<>(3,
             MinecraftJsonBuffer::new,
-            node -> new MinecraftJsonBuilder(node).build()),
+            node -> new MinecraftJsonBuilder(node).build(),
+            JsonElement::toString);
     /**
      * Minecraft legacy formatting codes as specified by
      * <a href="https://minecraft.fandom.com/wiki/Formatting_codes">Minecraft Wiki: Formatting codes</a>.
      */
-    MINECRAFT_LEGACY(4,
+    public static final Format<String> MINECRAFT_LEGACY = new Format<>(4,
             MinecraftLegacyBuffer::new,
-            node -> new MinecraftLegacyBuilder(node).build());
+            node -> new MinecraftLegacyBuilder(node).build(),
+            s -> s);
 
     private final int code;
     private final BiFunction<Node, String, Buffer> mutatorStringToNode;
-    private final   Function<Node, String>         mutatorNodeToString;
+    private final   Function<Node, T>              mutatorNodeToObject;
+    private final   Function<T   , String>         mutatorObjectToString;
 
-    Format(int code, BiFunction<Node, String, Buffer> mutatorStringToNode, Function<Node, String> mutatorNodeToString) {
+    private Format(int code, BiFunction<Node, String, Buffer> mutatorStringToNode, Function<Node, T> mutatorNodeToObject, Function<T, String> mutatorObjectToString) {
         this.code = code;
         this.mutatorStringToNode = mutatorStringToNode;
-        this.mutatorNodeToString = mutatorNodeToString;
+        this.mutatorNodeToObject = mutatorNodeToObject;
+        this.mutatorObjectToString = mutatorObjectToString;
     }
 
     /**
@@ -61,8 +69,18 @@ public enum Format {
         return mutatorStringToNode.apply(parent, raw);
     }
 
-    public Function<Node, String> getMutatorNodeToString() {
-        return mutatorNodeToString;
+    public Function<Node, T> getMutatorNodeToObject() {
+        return mutatorNodeToObject;
+    }
+
+    public Function<T, String> getMutatorObjectToString() {
+        return mutatorObjectToString;
+    }
+
+    /* - - - */
+
+    public static @NotNull Format<?>[] values() {
+        return new Format<?>[]{ PLAINTEXT, TURTLE, DISCORD, MINECRAFT_JSON, MINECRAFT_LEGACY };
     }
 
     /* - - - */

--- a/src/main/java/de/turtle_exception/fancyformat/Format.java
+++ b/src/main/java/de/turtle_exception/fancyformat/Format.java
@@ -11,12 +11,12 @@ import java.util.function.Function;
 /** Each value of this enum represents a specific text format that is supported by this library. */
 public final class Format<T> {
     /** Raw text that does not have any style or feature. */
-    public static final Format<String> PLAINTEXT = new Format<>(0,
+    public static final Format<String> PLAINTEXT = new Format<String>("PLAINTEXT", 0,
             PlaintextBuffer::new,
             node -> new PlaintextBuilder(node).build(),
             s -> s);
     /** A universal format that preserves every feature or style of every other format. */
-    public static final Format<JsonElement> TURTLE = new Format<>(1,
+    public static final Format<JsonElement> TURTLE = new Format<>("TURTLE", 1,
             TurtleBuffer::new,
             node -> new TurtleBuilder(node).build(),
             JsonElement::toString);
@@ -24,7 +24,7 @@ public final class Format<T> {
      * Discord Markdown format as specified by
      * <a href="https://support.discord.com/hc/en-us/articles/210298617">Discord Support: Markdown Text 101</a>.
      */
-    public static final Format<String> DISCORD = new Format<>(2,
+    public static final Format<String> DISCORD = new Format<String>("DISCORD", 2,
             DiscordBuffer::new,
             node -> new DiscordBuilder(node).build(),
             s -> s);
@@ -32,7 +32,7 @@ public final class Format<T> {
      * Minecraft JSON format as specified by
      * <a href="https://minecraft.fandom.com/wiki/Raw_JSON_text_format">Minecraft Wiki: Raw JSON text format</a>.
      */
-    public static final Format<JsonElement> MINECRAFT_JSON = new Format<>(3,
+    public static final Format<JsonElement> MINECRAFT_JSON = new Format<>("MINECRAFT_JSON", 3,
             MinecraftJsonBuffer::new,
             node -> new MinecraftJsonBuilder(node).build(),
             JsonElement::toString);
@@ -40,21 +40,27 @@ public final class Format<T> {
      * Minecraft legacy formatting codes as specified by
      * <a href="https://minecraft.fandom.com/wiki/Formatting_codes">Minecraft Wiki: Formatting codes</a>.
      */
-    public static final Format<String> MINECRAFT_LEGACY = new Format<>(4,
+    public static final Format<String> MINECRAFT_LEGACY = new Format<String>("MINECRAFT_LEGACY", 4,
             MinecraftLegacyBuffer::new,
             node -> new MinecraftLegacyBuilder(node).build(),
             s -> s);
 
+    private final String name;
     private final int code;
-    private final BiFunction<Node, String, Buffer> mutatorStringToNode;
+    private final BiFunction<Node, T, Buffer<T>> mutatorStringToNode;
     private final   Function<Node, T>              mutatorNodeToObject;
     private final   Function<T   , String>         mutatorObjectToString;
 
-    private Format(int code, BiFunction<Node, String, Buffer> mutatorStringToNode, Function<Node, T> mutatorNodeToObject, Function<T, String> mutatorObjectToString) {
+    private Format(@NotNull String name, int code, BiFunction<Node, T, Buffer<T>> mutatorStringToNode, Function<Node, T> mutatorNodeToObject, Function<T, String> mutatorObjectToString) {
+        this.name = name;
         this.code = code;
         this.mutatorStringToNode = mutatorStringToNode;
         this.mutatorNodeToObject = mutatorNodeToObject;
         this.mutatorObjectToString = mutatorObjectToString;
+    }
+
+    public @NotNull String getName() {
+        return name;
     }
 
     /**
@@ -65,7 +71,7 @@ public final class Format<T> {
         return code;
     }
 
-    public Buffer newBuffer(@NotNull Node parent, @NotNull String raw) {
+    public Buffer<T> newBuffer(@NotNull Node parent, @NotNull T raw) {
         return mutatorStringToNode.apply(parent, raw);
     }
 

--- a/src/main/java/de/turtle_exception/fancyformat/Format.java
+++ b/src/main/java/de/turtle_exception/fancyformat/Format.java
@@ -1,109 +1,75 @@
 package de.turtle_exception.fancyformat;
 
-import com.google.gson.JsonElement;
-import de.turtle_exception.fancyformat.buffers.*;
-import de.turtle_exception.fancyformat.builders.*;
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.TextComponent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-/** Each value of this enum represents a specific text format that is supported by this library. */
-public final class Format<T> {
-    /** Raw text that does not have any style or feature. */
-    public static final Format<String> PLAINTEXT = new Format<>("PLAINTEXT", 0,
-            PlaintextBuffer::new,
-            node -> new PlaintextBuilder(node).build(),
-            s -> s);
-    /** A universal format that preserves every feature or style of every other format. */
-    public static final Format<JsonElement> TURTLE = new Format<>("TURTLE", 1,
-            TurtleBuffer::new,
-            node -> new TurtleBuilder(node).build(),
-            JsonElement::toString);
-    /**
-     * Discord Markdown format as specified by
-     * <a href="https://support.discord.com/hc/en-us/articles/210298617">Discord Support: Markdown Text 101</a>.
-     */
-    public static final Format<String> DISCORD = new Format<>("DISCORD", 2,
-            DiscordBuffer::new,
-            node -> new DiscordBuilder(node).build(),
-            s -> s);
-    /**
-     * Minecraft JSON format as specified by
-     * <a href="https://minecraft.fandom.com/wiki/Raw_JSON_text_format">Minecraft Wiki: Raw JSON text format</a>.
-     */
-    public static final Format<JsonElement> MINECRAFT_JSON = new Format<>("MINECRAFT_JSON", 3,
-            MinecraftJsonBuffer::new,
-            node -> new MinecraftJsonBuilder(node).build(),
-            JsonElement::toString);
-    /**
-     * Minecraft legacy formatting codes as specified by
-     * <a href="https://minecraft.fandom.com/wiki/Formatting_codes">Minecraft Wiki: Formatting codes</a>.
-     */
-    public static final Format<String> MINECRAFT_LEGACY = new Format<>("MINECRAFT_LEGACY", 4,
-            MinecraftLegacyBuffer::new,
-            node -> new MinecraftLegacyBuilder(node).build(),
-            s -> s);
-    public static final Format<BaseComponent[]> SPIGOT_COMPONENTS = new Format<>("SPIGOT_FORMAT", 5,
-            SpigotComponentsBuffer::new,
-            node -> new SpigotComponentsBuilder(node).build(),
-            components -> new TextComponent(components).toLegacyText());
-
+public class Format<T> {
     private final String name;
-    private final int code;
-    private final BiFunction<Node, T, Buffer<T>> mutatorStringToNode;
-    private final   Function<Node, T>            mutatorNodeToObject;
-    private final   Function<T   , String>       mutatorObjectToString;
+    private final Class<T> type;
+    private final BiFunction<Node, T, Buffer<T>> bufferProvider;
+    private final Function<Node, MessageBuilder<T>> builderProvider;
+    private final Function<String, T> stringParser;
+    private final Function<T, String> typeParser;
 
-    private Format(@NotNull String name, int code, BiFunction<Node, T, Buffer<T>> mutatorStringToNode, Function<Node, T> mutatorNodeToObject, Function<T, String> mutatorObjectToString) {
+    public Format(
+            @NotNull String name,
+            @NotNull Class<T> type,
+            @NotNull BiFunction<Node, T, Buffer<T>> bufferProvider,
+            @NotNull Function<Node, MessageBuilder<T>> builderProvider,
+            @Nullable Function<String, T> stringParser,
+            @Nullable Function<T, String> typeParser
+    ) {
         this.name = name;
-        this.code = code;
-        this.mutatorStringToNode = mutatorStringToNode;
-        this.mutatorNodeToObject = mutatorNodeToObject;
-        this.mutatorObjectToString = mutatorObjectToString;
+        this.type = type;
+        this.bufferProvider = bufferProvider;
+        this.builderProvider = builderProvider;
+        this.stringParser = stringParser;
+        this.typeParser = typeParser;
     }
+
+    public Format(
+            @NotNull String name,
+            @NotNull Class<T> type,
+            @NotNull BiFunction<Node, T, Buffer<T>> bufferProvider,
+            @NotNull Function<Node, MessageBuilder<T>> builderProvider
+    ) {
+        this(name, type, bufferProvider, builderProvider, null, null);
+    }
+
+    /* - - - */
+
+    public @NotNull Buffer<T> newBuffer(@NotNull Node parent, @NotNull T raw) {
+        return bufferProvider.apply(parent, raw);
+    }
+
+    public @NotNull MessageBuilder<T> newBuilder(@NotNull Node node) {
+        return builderProvider.apply(node);
+    }
+
+    /* - - - */
 
     public @NotNull String getName() {
         return name;
     }
 
-    /**
-     * Provides a unique code representing this Format. Used for serialization in native text.
-     * @return Unique code of this Format.
-     */
-    public int getCode() {
-        return code;
-    }
-
-    public Buffer<T> newBuffer(@NotNull Node parent, @NotNull T raw) {
-        return mutatorStringToNode.apply(parent, raw);
-    }
-
-    public Function<Node, T> getMutatorNodeToObject() {
-        return mutatorNodeToObject;
-    }
-
-    public Function<T, String> getMutatorObjectToString() {
-        return mutatorObjectToString;
+    public @NotNull Class<T> getType() {
+        return type;
     }
 
     /* - - - */
 
-    public static @NotNull Format<?>[] values() {
-        return new Format<?>[]{ PLAINTEXT, TURTLE, DISCORD, MINECRAFT_JSON, MINECRAFT_LEGACY };
+    public @NotNull T makeObject(@NotNull String str) throws UnsupportedOperationException {
+        if (stringParser == null)
+            throw new UnsupportedOperationException("Cannot parse String to object.");
+        return stringParser.apply(str);
     }
 
-    /* - - - */
-
-    /**
-     * Creates a native text String of this format and the provided message.
-     * @param raw Message of this format.
-     * @return Native text representation of {@code raw}.
-     */
-    @SuppressWarnings("unused")
-    public @NotNull String toNative(@NotNull String raw) {
-        return this.getCode() + "#" + raw;
+    public @NotNull String makeString(@NotNull T t) throws UnsupportedOperationException {
+        if (typeParser == null)
+            throw new UnsupportedOperationException("Cannot parse object to String.");
+        return typeParser.apply(t);
     }
 }

--- a/src/main/java/de/turtle_exception/fancyformat/FormatText.java
+++ b/src/main/java/de/turtle_exception/fancyformat/FormatText.java
@@ -14,10 +14,10 @@ import java.util.function.Predicate;
 /**
  * A FormatText is an abstract representation of a text that has been parsed from a formatted text. It can be used to
  * translate that text into any supported {@link Format}.
- * @see FancyFormatter#newText(String, Format)
+ * @see FancyFormatter#newText(Object, Format)
  */
 @SuppressWarnings("unused")
-public class FormatText {
+public class FormatText<T> {
     private final Node root;
     private final int size;
 
@@ -31,7 +31,7 @@ public class FormatText {
      * FormatText text = formatter.newText(content, format);
      * } </pre>
      */
-    FormatText(@NotNull FancyFormatter formatter, @NotNull String content, @NotNull Format<?> format) {
+    FormatText(@NotNull FancyFormatter formatter, @NotNull T content, @NotNull Format<T> format) {
         this.root = new RootNode(formatter, content, format);
         this.size = this.root.resolve();
     }

--- a/src/main/java/de/turtle_exception/fancyformat/FormatText.java
+++ b/src/main/java/de/turtle_exception/fancyformat/FormatText.java
@@ -1,6 +1,7 @@
 package de.turtle_exception.fancyformat;
 
 import com.google.gson.JsonElement;
+import de.turtle_exception.fancyformat.formats.TurtleFormat;
 import de.turtle_exception.fancyformat.nodes.MentionNode;
 import de.turtle_exception.fancyformat.nodes.RootNode;
 import org.jetbrains.annotations.NotNull;
@@ -14,10 +15,10 @@ import java.util.function.Predicate;
 /**
  * A FormatText is an abstract representation of a text that has been parsed from a formatted text. It can be used to
  * translate that text into any supported {@link Format}.
- * @see FancyFormatter#newText(Object, Format)
+ * @see FancyFormatter#fromFormat(Object, Format)
  */
 @SuppressWarnings("unused")
-public class FormatText<T> {
+public class FormatText {
     private final Node root;
     private final int size;
 
@@ -28,23 +29,23 @@ public class FormatText<T> {
      * <pre> {@code
      * // reuse this formatter for other texts
      * FancyFormatter formatter = new FancyFormatter();
-     * FormatText text = formatter.newText(content, format);
+     * FormatText text = formatter.from(content, format);
      * } </pre>
      */
-    FormatText(@NotNull FancyFormatter formatter, @NotNull T content, @NotNull Format<T> format) {
-        this.root = new RootNode(formatter, content, format);
+    <T> FormatText(@NotNull FancyFormatter formatter, @NotNull T content, @NotNull Format<T> format) {
+        this.root = new RootNode<>(formatter, content, format);
         this.size = this.root.resolve();
     }
 
     @SuppressWarnings("unchecked")
-    public synchronized <T> @NotNull T parse(@NotNull Format<T> format) {
+    public synchronized <U> @NotNull U parse(@NotNull Format<U> format) {
         if (!cache.containsKey(format))
-            cache.put(format, root.toString(format));
-        return (T) cache.get(format);
+            cache.put(format, root.parse(format));
+        return (U) cache.get(format);
     }
 
     public JsonElement parse() {
-        return this.parse(Format.TURTLE);
+        return this.parse(TurtleFormat.get());
     }
 
     /**
@@ -52,14 +53,14 @@ public class FormatText<T> {
      * @param format Desired text format.
      * @return String representation of this text in the desired format.
      */
-    public <T> @NotNull String toString(@NotNull Format<T> format) {
-        return format.getMutatorObjectToString().apply(this.parse(format));
+    public <U> @NotNull String toString(@NotNull Format<U> format) {
+        return format.makeString(this.parse(format));
     }
 
-    /** Returns this text in the {@link Format#TURTLE} format. */
+    /** Returns this text in the {@link TurtleFormat}. */
     @Override
     public String toString() {
-        return this.toString(Format.TURTLE);
+        return this.toString(TurtleFormat.get());
     }
 
     /* - MENTIONS - */

--- a/src/main/java/de/turtle_exception/fancyformat/MessageBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/MessageBuilder.java
@@ -3,14 +3,14 @@ package de.turtle_exception.fancyformat;
 import com.google.gson.Gson;
 import org.jetbrains.annotations.NotNull;
 
-public abstract class MessageBuilder {
+public abstract class MessageBuilder<T> {
     protected final @NotNull Node node;
 
     protected MessageBuilder(@NotNull Node node) {
         this.node = node;
     }
 
-    public abstract @NotNull String build();
+    public abstract @NotNull T build();
 
     protected @NotNull Gson getGson() {
         return node.getFormatter().getGson();

--- a/src/main/java/de/turtle_exception/fancyformat/Node.java
+++ b/src/main/java/de/turtle_exception/fancyformat/Node.java
@@ -18,8 +18,12 @@ public class Node {
 
     /* - - - */
 
-    public @NotNull String toString(@NotNull Format format) {
-        return format.getMutatorNodeToString().apply(this);
+    public <T> @NotNull T parse(@NotNull Format<T> format) {
+        return format.getMutatorNodeToObject().apply(this);
+    }
+
+    public <T> @NotNull String toString(@NotNull Format<T> format) {
+        return format.getMutatorObjectToString().apply(this.parse(format));
     }
 
     @Override

--- a/src/main/java/de/turtle_exception/fancyformat/Node.java
+++ b/src/main/java/de/turtle_exception/fancyformat/Node.java
@@ -1,5 +1,6 @@
 package de.turtle_exception.fancyformat;
 
+import de.turtle_exception.fancyformat.formats.TurtleFormat;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,16 +20,16 @@ public class Node {
     /* - - - */
 
     public <T> @NotNull T parse(@NotNull Format<T> format) {
-        return format.getMutatorNodeToObject().apply(this);
+        return format.newBuilder(this).build();
     }
 
     public <T> @NotNull String toString(@NotNull Format<T> format) {
-        return format.getMutatorObjectToString().apply(this.parse(format));
+        return format.makeString(this.parse(format));
     }
 
     @Override
     public String toString() {
-        return this.toString(Format.TURTLE);
+        return this.toString(TurtleFormat.get());
     }
 
     public @NotNull FancyFormatter getFormatter() {

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/DiscordBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/DiscordBuffer.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Range;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DiscordBuffer extends Buffer {
+public class DiscordBuffer extends Buffer<String> {
     private final StyleMarker markerBold          = new StyleMarker('*', 2, FormatStyle.BOLD);
     private final StyleMarker markerItalicsStar   = new StyleMarker('*', 1, FormatStyle.ITALICS);
     private final StyleMarker markerUnderline     = new StyleMarker('_', 2, FormatStyle.UNDERLINE);
@@ -38,7 +38,7 @@ public class DiscordBuffer extends Buffer {
     private boolean done = false;
 
     public DiscordBuffer(@NotNull Node parent, @NotNull String raw) {
-        super(parent, raw);
+        super(parent, raw, Format.DISCORD);
     }
 
     public @NotNull List<Node> parse() {
@@ -51,8 +51,8 @@ public class DiscordBuffer extends Buffer {
             int linebreak = raw.indexOf("\n");
             String   line = raw.substring(2, linebreak != -1 ? linebreak : raw.length());
 
-            StyleNode      commentNode = new StyleNode(parent, Quote.SINGLE_LINE);
-            UnresolvedNode contentNode = new UnresolvedNode(commentNode, line, Format.DISCORD);
+            StyleNode              commentNode = new StyleNode(parent, Quote.SINGLE_LINE);
+            UnresolvedNode<String> contentNode = new UnresolvedNode<>(commentNode, line, Format.DISCORD);
             contentNode.notifyParent();
 
             return List.of(commentNode);
@@ -60,8 +60,8 @@ public class DiscordBuffer extends Buffer {
 
         // check for multi line comment
         if (raw.startsWith(">>> ")) {
-            StyleNode      commentNode = new StyleNode(parent, Quote.MULTI_LINE);
-            UnresolvedNode contentNode = new UnresolvedNode(commentNode, raw.substring(4), Format.DISCORD);
+            StyleNode              commentNode = new StyleNode(parent, Quote.MULTI_LINE);
+            UnresolvedNode<String> contentNode = new UnresolvedNode<>(commentNode, raw.substring(4), Format.DISCORD);
             contentNode.notifyParent();
 
             return List.of(commentNode);
@@ -144,19 +144,19 @@ public class DiscordBuffer extends Buffer {
             str2 = raw.substring(outerFormat.startIndex + outerFormat.length, outerFormat.endIndex);
             str3 = raw.substring(outerFormat.endIndex + outerFormat.length);
 
-            StyleNode        styleNode = new StyleNode(parent, outerFormat.style);
-            UnresolvedNode contentNode = new UnresolvedNode(styleNode, str2, Format.DISCORD);
+            StyleNode                styleNode = new StyleNode(parent, outerFormat.style);
+            UnresolvedNode<String> contentNode = new UnresolvedNode<>(styleNode, str2, Format.DISCORD);
             contentNode.notifyParent();
 
             ArrayList<Node> nodes = new ArrayList<>();
 
             if (!str1.isEmpty() && !str1.isBlank())
-                nodes.add(new UnresolvedNode(parent, str1, Format.DISCORD));
+                nodes.add(new UnresolvedNode<>(parent, str1, Format.DISCORD));
 
             nodes.add(styleNode);
 
             if (!str3.isEmpty() && !str3.isBlank())
-                nodes.add(new UnresolvedNode(parent, str3, Format.DISCORD));
+                nodes.add(new UnresolvedNode<>(parent, str3, Format.DISCORD));
 
             return nodes;
         }
@@ -178,12 +178,12 @@ public class DiscordBuffer extends Buffer {
             ArrayList<Node> nodes = new ArrayList<>();
 
             if (!str1.isEmpty() && !str1.isBlank())
-                nodes.add(new UnresolvedNode(parent, str1, Format.DISCORD));
+                nodes.add(new UnresolvedNode<>(parent, str1, Format.DISCORD));
 
             nodes.add(mentionNode);
 
             if (!str3.isEmpty() && !str3.isBlank())
-                nodes.add(new UnresolvedNode(parent, str3, Format.DISCORD));
+                nodes.add(new UnresolvedNode<>(parent, str3, Format.DISCORD));
 
             return nodes;
         }

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/DiscordBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/DiscordBuffer.java
@@ -1,6 +1,7 @@
 package de.turtle_exception.fancyformat.buffers;
 
 import de.turtle_exception.fancyformat.*;
+import de.turtle_exception.fancyformat.formats.DiscordFormat;
 import de.turtle_exception.fancyformat.nodes.MentionNode;
 import de.turtle_exception.fancyformat.nodes.StyleNode;
 import de.turtle_exception.fancyformat.nodes.UnresolvedNode;
@@ -38,7 +39,7 @@ public class DiscordBuffer extends Buffer<String> {
     private boolean done = false;
 
     public DiscordBuffer(@NotNull Node parent, @NotNull String raw) {
-        super(parent, raw, Format.DISCORD);
+        super(parent, raw, DiscordFormat.get());
     }
 
     public @NotNull List<Node> parse() {
@@ -52,7 +53,7 @@ public class DiscordBuffer extends Buffer<String> {
             String   line = raw.substring(2, linebreak != -1 ? linebreak : raw.length());
 
             StyleNode              commentNode = new StyleNode(parent, Quote.SINGLE_LINE);
-            UnresolvedNode<String> contentNode = new UnresolvedNode<>(commentNode, line, Format.DISCORD);
+            UnresolvedNode<String> contentNode = new UnresolvedNode<>(commentNode, line, DiscordFormat.get());
             contentNode.notifyParent();
 
             return List.of(commentNode);
@@ -61,7 +62,7 @@ public class DiscordBuffer extends Buffer<String> {
         // check for multi line comment
         if (raw.startsWith(">>> ")) {
             StyleNode              commentNode = new StyleNode(parent, Quote.MULTI_LINE);
-            UnresolvedNode<String> contentNode = new UnresolvedNode<>(commentNode, raw.substring(4), Format.DISCORD);
+            UnresolvedNode<String> contentNode = new UnresolvedNode<>(commentNode, raw.substring(4), DiscordFormat.get());
             contentNode.notifyParent();
 
             return List.of(commentNode);
@@ -145,18 +146,18 @@ public class DiscordBuffer extends Buffer<String> {
             str3 = raw.substring(outerFormat.endIndex + outerFormat.length);
 
             StyleNode                styleNode = new StyleNode(parent, outerFormat.style);
-            UnresolvedNode<String> contentNode = new UnresolvedNode<>(styleNode, str2, Format.DISCORD);
+            UnresolvedNode<String> contentNode = new UnresolvedNode<>(styleNode, str2, DiscordFormat.get());
             contentNode.notifyParent();
 
             ArrayList<Node> nodes = new ArrayList<>();
 
             if (!str1.isEmpty() && !str1.isBlank())
-                nodes.add(new UnresolvedNode<>(parent, str1, Format.DISCORD));
+                nodes.add(new UnresolvedNode<>(parent, str1, DiscordFormat.get()));
 
             nodes.add(styleNode);
 
             if (!str3.isEmpty() && !str3.isBlank())
-                nodes.add(new UnresolvedNode<>(parent, str3, Format.DISCORD));
+                nodes.add(new UnresolvedNode<>(parent, str3, DiscordFormat.get()));
 
             return nodes;
         }
@@ -178,12 +179,12 @@ public class DiscordBuffer extends Buffer<String> {
             ArrayList<Node> nodes = new ArrayList<>();
 
             if (!str1.isEmpty() && !str1.isBlank())
-                nodes.add(new UnresolvedNode<>(parent, str1, Format.DISCORD));
+                nodes.add(new UnresolvedNode<>(parent, str1, DiscordFormat.get()));
 
             nodes.add(mentionNode);
 
             if (!str3.isEmpty() && !str3.isBlank())
-                nodes.add(new UnresolvedNode<>(parent, str3, Format.DISCORD));
+                nodes.add(new UnresolvedNode<>(parent, str3, DiscordFormat.get()));
 
             return nodes;
         }

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/MinecraftJsonBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/MinecraftJsonBuffer.java
@@ -17,28 +17,24 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-// TODO: this is extremely inefficient
 // TODO: this ignored a 'false' formatting override
-public class MinecraftJsonBuffer extends Buffer {
-    private JsonElement json;
+public class MinecraftJsonBuffer extends Buffer<JsonElement> {
     private JsonObject object;
 
-    public MinecraftJsonBuffer(@NotNull Node parent, @NotNull String raw) {
-        super(parent, raw);
+    public MinecraftJsonBuffer(@NotNull Node parent, @NotNull JsonElement raw) {
+        super(parent, raw, Format.MINECRAFT_JSON);
     }
 
     @Override
     public @NotNull List<Node> parse() {
-        json = getGson().fromJson(raw, JsonElement.class);
-
-        if (json instanceof JsonPrimitive primitive)
+        if (raw instanceof JsonPrimitive primitive)
             return List.of(new TextNode(parent, primitive.getAsString()));
 
-        if (json instanceof JsonArray arr) {
+        if (raw instanceof JsonArray arr) {
             ArrayList<Node> nodes = new ArrayList<>();
 
             for (JsonElement element : arr) {
-                UnresolvedNode node = new UnresolvedNode(parent, element.toString(), Format.MINECRAFT_JSON);
+                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(parent, element, Format.MINECRAFT_JSON);
                 node.notifyParent();
 
                 nodes.add(node);
@@ -47,8 +43,8 @@ public class MinecraftJsonBuffer extends Buffer {
             return nodes;
         }
 
-        if (json instanceof JsonObject) {
-            this.object = ((JsonObject) json);
+        if (raw instanceof JsonObject) {
+            this.object = ((JsonObject) raw);
         } else {
             return this.asText();
         }
@@ -58,8 +54,8 @@ public class MinecraftJsonBuffer extends Buffer {
             for (Color value : Color.values()) {
                 if (!color.equals(value.getName())) continue;
 
-                StyleNode        styleNode = new StyleNode(parent, value);
-                UnresolvedNode contentNode = new UnresolvedNode(styleNode, toReducedString("color"), Format.MINECRAFT_JSON);
+                StyleNode                     styleNode = new StyleNode(parent, value);
+                UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(styleNode, reduce("color"), Format.MINECRAFT_JSON);
                 contentNode.notifyParent();
 
                 return List.of(styleNode);
@@ -69,8 +65,8 @@ public class MinecraftJsonBuffer extends Buffer {
         for (FormatStyle value : FormatStyle.values()) {
             if (!isTrue(value.getName())) continue;
 
-            StyleNode        styleNode = new StyleNode(parent, value);
-            UnresolvedNode contentNode = new UnresolvedNode(styleNode, toReducedString(value.getName()), Format.MINECRAFT_JSON);
+            StyleNode                     styleNode = new StyleNode(parent, value);
+            UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(styleNode, reduce(value.getName()), Format.MINECRAFT_JSON);
             contentNode.notifyParent();
 
             return List.of(styleNode);
@@ -78,8 +74,8 @@ public class MinecraftJsonBuffer extends Buffer {
 
         JsonObject clickEvent = getOptional(() -> object.getAsJsonObject("clickEvent"));
         if (clickEvent != null) {
-            ClickNode        clickNode = new ClickNode(parent, clickEvent.get("action").getAsString(), clickEvent.get("value").getAsString());
-            UnresolvedNode contentNode = new UnresolvedNode(clickNode, toReducedString("clickEvent"), Format.MINECRAFT_JSON);
+            ClickNode                     clickNode = new ClickNode(parent, clickEvent.get("action").getAsString(), clickEvent.get("value").getAsString());
+            UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(clickNode, reduce("clickEvent"), Format.MINECRAFT_JSON);
             contentNode.notifyParent();
 
             return List.of(clickNode);
@@ -87,8 +83,8 @@ public class MinecraftJsonBuffer extends Buffer {
 
         JsonObject hoverEvent = getOptional(() -> object.getAsJsonObject("hoverEvent"));
         if (hoverEvent != null) {
-            HoverNode        hoverNode = new HoverNode(parent, hoverEvent.get("action").getAsString(), hoverEvent.getAsJsonArray("contents"));
-            UnresolvedNode contentNode = new UnresolvedNode(hoverNode, toReducedString("hoverEvent"), Format.MINECRAFT_JSON);
+            HoverNode                     hoverNode = new HoverNode(parent, hoverEvent.get("action").getAsString(), hoverEvent.getAsJsonArray("contents"));
+            UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(hoverNode, reduce("hoverEvent"), Format.MINECRAFT_JSON);
             contentNode.notifyParent();
 
             return List.of(hoverNode);
@@ -105,7 +101,7 @@ public class MinecraftJsonBuffer extends Buffer {
         JsonArray extra = getOptional(() -> object.getAsJsonArray("extra"));
         if (extra != null) {
             for (JsonElement child : extra) {
-                UnresolvedNode node = new UnresolvedNode(parent, child.toString(), Format.MINECRAFT_JSON);
+                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(parent, child, Format.MINECRAFT_JSON);
                 node.notifyParent();
 
                 nodes.add(node);
@@ -133,8 +129,8 @@ public class MinecraftJsonBuffer extends Buffer {
         }
     }
 
-    private @NotNull String toReducedString(@NotNull String key) {
+    private @NotNull JsonObject reduce(@NotNull String key) {
         object.remove(key);
-        return object.toString();
+        return object;
     }
 }

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/MinecraftJsonBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/MinecraftJsonBuffer.java
@@ -5,8 +5,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import de.turtle_exception.fancyformat.Buffer;
-import de.turtle_exception.fancyformat.Format;
 import de.turtle_exception.fancyformat.Node;
+import de.turtle_exception.fancyformat.formats.MinecraftJsonFormat;
 import de.turtle_exception.fancyformat.nodes.*;
 import de.turtle_exception.fancyformat.styles.Color;
 import de.turtle_exception.fancyformat.styles.FormatStyle;
@@ -22,7 +22,7 @@ public class MinecraftJsonBuffer extends Buffer<JsonElement> {
     private JsonObject object;
 
     public MinecraftJsonBuffer(@NotNull Node parent, @NotNull JsonElement raw) {
-        super(parent, raw, Format.MINECRAFT_JSON);
+        super(parent, raw, MinecraftJsonFormat.get());
     }
 
     @Override
@@ -34,7 +34,7 @@ public class MinecraftJsonBuffer extends Buffer<JsonElement> {
             ArrayList<Node> nodes = new ArrayList<>();
 
             for (JsonElement element : arr) {
-                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(parent, element, Format.MINECRAFT_JSON);
+                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(parent, element, MinecraftJsonFormat.get());
                 node.notifyParent();
 
                 nodes.add(node);
@@ -55,7 +55,7 @@ public class MinecraftJsonBuffer extends Buffer<JsonElement> {
                 if (!color.equals(value.getName())) continue;
 
                 StyleNode                     styleNode = new StyleNode(parent, value);
-                UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(styleNode, reduce("color"), Format.MINECRAFT_JSON);
+                UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(styleNode, reduce("color"), MinecraftJsonFormat.get());
                 contentNode.notifyParent();
 
                 return List.of(styleNode);
@@ -66,7 +66,7 @@ public class MinecraftJsonBuffer extends Buffer<JsonElement> {
             if (!isTrue(value.getName())) continue;
 
             StyleNode                     styleNode = new StyleNode(parent, value);
-            UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(styleNode, reduce(value.getName()), Format.MINECRAFT_JSON);
+            UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(styleNode, reduce(value.getName()), MinecraftJsonFormat.get());
             contentNode.notifyParent();
 
             return List.of(styleNode);
@@ -75,7 +75,7 @@ public class MinecraftJsonBuffer extends Buffer<JsonElement> {
         JsonObject clickEvent = getOptional(() -> object.getAsJsonObject("clickEvent"));
         if (clickEvent != null) {
             ClickNode                     clickNode = new ClickNode(parent, clickEvent.get("action").getAsString(), clickEvent.get("value").getAsString());
-            UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(clickNode, reduce("clickEvent"), Format.MINECRAFT_JSON);
+            UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(clickNode, reduce("clickEvent"), MinecraftJsonFormat.get());
             contentNode.notifyParent();
 
             return List.of(clickNode);
@@ -84,7 +84,7 @@ public class MinecraftJsonBuffer extends Buffer<JsonElement> {
         JsonObject hoverEvent = getOptional(() -> object.getAsJsonObject("hoverEvent"));
         if (hoverEvent != null) {
             HoverNode                     hoverNode = new HoverNode(parent, hoverEvent.get("action").getAsString(), hoverEvent.getAsJsonArray("contents"));
-            UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(hoverNode, reduce("hoverEvent"), Format.MINECRAFT_JSON);
+            UnresolvedNode<JsonElement> contentNode = new UnresolvedNode<>(hoverNode, reduce("hoverEvent"), MinecraftJsonFormat.get());
             contentNode.notifyParent();
 
             return List.of(hoverNode);
@@ -101,7 +101,7 @@ public class MinecraftJsonBuffer extends Buffer<JsonElement> {
         JsonArray extra = getOptional(() -> object.getAsJsonArray("extra"));
         if (extra != null) {
             for (JsonElement child : extra) {
-                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(parent, child, Format.MINECRAFT_JSON);
+                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(parent, child, MinecraftJsonFormat.get());
                 node.notifyParent();
 
                 nodes.add(node);

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/MinecraftLegacyBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/MinecraftLegacyBuffer.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MinecraftLegacyBuffer extends Buffer {
+public class MinecraftLegacyBuffer extends Buffer<String> {
     private char code      = ' ';
     private int  codeIndex = -1;
     private int resetIndex = -1;
@@ -26,7 +26,7 @@ public class MinecraftLegacyBuffer extends Buffer {
     private boolean done = false;
 
     public MinecraftLegacyBuffer(@NotNull Node parent, @NotNull String raw) {
-        super(parent, raw);
+        super(parent, raw, Format.MINECRAFT_LEGACY);
     }
 
     @Override
@@ -68,8 +68,8 @@ public class MinecraftLegacyBuffer extends Buffer {
         String contentStr = raw.substring(codeIndex + 2, resetIndex != -1 ? resetIndex : raw.length());
 
         @SuppressWarnings("ConstantConditions") // getStyle() cannot return null here because it has been checked before
-        StyleNode        styleNode = new StyleNode(parent, getStyle(code));
-        UnresolvedNode contentNode = new UnresolvedNode(styleNode, contentStr, Format.MINECRAFT_LEGACY);
+        StyleNode                styleNode = new StyleNode(parent, getStyle(code));
+        UnresolvedNode<String> contentNode = new UnresolvedNode<>(styleNode, contentStr, Format.MINECRAFT_LEGACY);
         contentNode.notifyParent();
 
 
@@ -81,7 +81,7 @@ public class MinecraftLegacyBuffer extends Buffer {
         nodes.add(styleNode);
 
         if (resetIndex > codeIndex + 2)
-            nodes.add(new UnresolvedNode(parent, raw.substring(resetIndex + (newline ? 0 : 2)), Format.MINECRAFT_LEGACY));
+            nodes.add(new UnresolvedNode<>(parent, raw.substring(resetIndex + (newline ? 0 : 2)), Format.MINECRAFT_LEGACY));
 
         return nodes;
     }

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/MinecraftLegacyBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/MinecraftLegacyBuffer.java
@@ -1,9 +1,9 @@
 package de.turtle_exception.fancyformat.buffers;
 
 import de.turtle_exception.fancyformat.Buffer;
-import de.turtle_exception.fancyformat.Format;
 import de.turtle_exception.fancyformat.Node;
 import de.turtle_exception.fancyformat.Style;
+import de.turtle_exception.fancyformat.formats.MinecraftLegacyFormat;
 import de.turtle_exception.fancyformat.nodes.StyleNode;
 import de.turtle_exception.fancyformat.nodes.TextNode;
 import de.turtle_exception.fancyformat.nodes.UnresolvedNode;
@@ -26,7 +26,7 @@ public class MinecraftLegacyBuffer extends Buffer<String> {
     private boolean done = false;
 
     public MinecraftLegacyBuffer(@NotNull Node parent, @NotNull String raw) {
-        super(parent, raw, Format.MINECRAFT_LEGACY);
+        super(parent, raw, MinecraftLegacyFormat.get());
     }
 
     @Override
@@ -69,7 +69,7 @@ public class MinecraftLegacyBuffer extends Buffer<String> {
 
         @SuppressWarnings("ConstantConditions") // getStyle() cannot return null here because it has been checked before
         StyleNode                styleNode = new StyleNode(parent, getStyle(code));
-        UnresolvedNode<String> contentNode = new UnresolvedNode<>(styleNode, contentStr, Format.MINECRAFT_LEGACY);
+        UnresolvedNode<String> contentNode = new UnresolvedNode<>(styleNode, contentStr, MinecraftLegacyFormat.get());
         contentNode.notifyParent();
 
 
@@ -81,7 +81,7 @@ public class MinecraftLegacyBuffer extends Buffer<String> {
         nodes.add(styleNode);
 
         if (resetIndex > codeIndex + 2)
-            nodes.add(new UnresolvedNode<>(parent, raw.substring(resetIndex + (newline ? 0 : 2)), Format.MINECRAFT_LEGACY));
+            nodes.add(new UnresolvedNode<>(parent, raw.substring(resetIndex + (newline ? 0 : 2)), MinecraftLegacyFormat.get()));
 
         return nodes;
     }

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/PlaintextBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/PlaintextBuffer.java
@@ -1,14 +1,15 @@
 package de.turtle_exception.fancyformat.buffers;
 
 import de.turtle_exception.fancyformat.Buffer;
+import de.turtle_exception.fancyformat.Format;
 import de.turtle_exception.fancyformat.Node;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public class PlaintextBuffer extends Buffer {
+public class PlaintextBuffer extends Buffer<String> {
     public PlaintextBuffer(@NotNull Node parent, @NotNull String raw) {
-        super(parent, raw);
+        super(parent, raw, Format.PLAINTEXT);
     }
 
     @Override

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/PlaintextBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/PlaintextBuffer.java
@@ -1,15 +1,15 @@
 package de.turtle_exception.fancyformat.buffers;
 
 import de.turtle_exception.fancyformat.Buffer;
-import de.turtle_exception.fancyformat.Format;
 import de.turtle_exception.fancyformat.Node;
+import de.turtle_exception.fancyformat.formats.PlaintextFormat;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public class PlaintextBuffer extends Buffer<String> {
     public PlaintextBuffer(@NotNull Node parent, @NotNull String raw) {
-        super(parent, raw, Format.PLAINTEXT);
+        super(parent, raw, PlaintextFormat.get());
     }
 
     @Override

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/SpigotComponentsBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/SpigotComponentsBuffer.java
@@ -183,6 +183,11 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
             }
         }
 
+        // remove first node if it's an empty TextNode
+        if (nodes.size() > 1)
+            if (nodes.get(0) instanceof TextNode tNode && tNode.getContent().isEmpty())
+                nodes.remove(0);
+
         return nodes;
     }
 

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/SpigotComponentsBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/SpigotComponentsBuffer.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
     public SpigotComponentsBuffer(@NotNull Node parent, @NotNull BaseComponent[] raw) {
@@ -62,64 +63,24 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
         // TODO: handle false overrides
 
         Boolean bold = component.isBoldRaw();
-        if (bold != null && bold) {
-            BaseComponent duplicate = component.duplicate();
-            duplicate.setBold(null);
-
-            StyleNode styleNode = new StyleNode(parent, FormatStyle.BOLD);
-            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
-            contentNode.notifyParent();
-
-            return List.of(styleNode);
-        }
+        if (bold != null && bold)
+            return handleFormat(component, FormatStyle.BOLD, c -> c.setBold(null));
 
         Boolean italic = component.isItalicRaw();
-        if (italic != null && italic) {
-            BaseComponent duplicate = component.duplicate();
-            duplicate.setItalic(null);
-
-            StyleNode styleNode = new StyleNode(parent, FormatStyle.ITALICS);
-            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
-            contentNode.notifyParent();
-
-            return List.of(styleNode);
-        }
+        if (italic != null && italic)
+            return handleFormat(component, FormatStyle.ITALICS, c -> c.setItalic(null));
 
         Boolean underline = component.isUnderlinedRaw();
-        if (underline != null && underline) {
-            BaseComponent duplicate = component.duplicate();
-            duplicate.setUnderlined(null);
-
-            StyleNode styleNode = new StyleNode(parent, FormatStyle.UNDERLINE);
-            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
-            contentNode.notifyParent();
-
-            return List.of(styleNode);
-        }
+        if (underline != null && underline)
+            return handleFormat(component, FormatStyle.UNDERLINE, c -> c.setUnderlined(null));
 
         Boolean strikethrough = component.isStrikethroughRaw();
-        if (strikethrough != null && strikethrough) {
-            BaseComponent duplicate = component.duplicate();
-            duplicate.setStrikethrough(null);
-
-            StyleNode styleNode = new StyleNode(parent, FormatStyle.STRIKETHROUGH);
-            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
-            contentNode.notifyParent();
-
-            return List.of(styleNode);
-        }
+        if (strikethrough != null && strikethrough)
+            return handleFormat(component, FormatStyle.STRIKETHROUGH, c -> c.setStrikethrough(null));
 
         Boolean spoiler = component.isObfuscatedRaw();
-        if (spoiler != null && spoiler) {
-            BaseComponent duplicate = component.duplicate();
-            duplicate.setObfuscated(null);
-
-            StyleNode styleNode = new StyleNode(parent, FormatStyle.SPOILER);
-            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
-            contentNode.notifyParent();
-
-            return List.of(styleNode);
-        }
+        if (spoiler != null && spoiler)
+            return handleFormat(component, FormatStyle.SPOILER, c -> c.setObfuscated(null));
 
         ClickEvent clickEvent = component.getClickEvent();
         if (clickEvent != null) {
@@ -221,5 +182,16 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
         }
 
         return nodes;
+    }
+
+    private @NotNull List<Node> handleFormat(@NotNull BaseComponent component, @NotNull FormatStyle style, @NotNull Consumer<BaseComponent> setter) {
+        BaseComponent duplicate = component.duplicate();
+        setter.accept(duplicate);
+
+        StyleNode styleNode = new StyleNode(parent, style);
+        UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+        contentNode.notifyParent();
+
+        return List.of(styleNode);
     }
 }

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/SpigotComponentsBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/SpigotComponentsBuffer.java
@@ -110,8 +110,8 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
                 for (Content content : contentsRaw) {
                     Object value = ((Text) content).getValue();
 
-                    if (value instanceof BaseComponent comp) {
-                        FormatText contentText = parent.getFormatter().fromFormat(new BaseComponent[]{ comp }, SpigotComponentsFormat.get());
+                    if (value instanceof BaseComponent[] comp) {
+                        FormatText contentText = parent.getFormatter().fromFormat(comp, SpigotComponentsFormat.get());
 
                         arr.add(contentText.parse(MinecraftJsonFormat.get()));
                     }

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/SpigotComponentsBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/SpigotComponentsBuffer.java
@@ -1,0 +1,225 @@
+package de.turtle_exception.fancyformat.buffers;
+
+import com.google.gson.*;
+import de.turtle_exception.fancyformat.*;
+import de.turtle_exception.fancyformat.nodes.*;
+import de.turtle_exception.fancyformat.styles.Color;
+import de.turtle_exception.fancyformat.styles.FormatStyle;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.*;
+import net.md_5.bungee.api.chat.hover.content.Content;
+import net.md_5.bungee.api.chat.hover.content.Entity;
+import net.md_5.bungee.api.chat.hover.content.Item;
+import net.md_5.bungee.api.chat.hover.content.Text;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
+    public SpigotComponentsBuffer(@NotNull Node parent, @NotNull BaseComponent[] raw) {
+        super(parent, raw, Format.SPIGOT_COMPONENTS);
+    }
+
+    @Override
+    public @NotNull List<Node> parse() {
+        if (raw.length == 0)
+            return List.of();
+
+        if (raw.length > 1) {
+            ArrayList<Node> nodes = new ArrayList<>();
+
+            for (BaseComponent component : raw) {
+                UnresolvedNode<BaseComponent[]> node = new UnresolvedNode<>(parent, new BaseComponent[]{ component }, Format.SPIGOT_COMPONENTS);
+                node.notifyParent();
+
+                nodes.add(node);
+            }
+
+            return nodes;
+        }
+
+        BaseComponent component = raw[0];
+
+        ChatColor color = component.getColorRaw();
+        if (color != null) {
+            for (Color value : Color.values()) {
+                if (!color.getName().equals(value.getName())) continue;
+
+                BaseComponent duplicate = component.duplicate();
+                duplicate.setColor(null);
+
+                StyleNode styleNode = new StyleNode(parent, value);
+                UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+                contentNode.notifyParent();
+
+                return List.of(styleNode);
+            }
+
+            // TODO: hex colors
+        }
+
+        // TODO: handle false overrides
+
+        Boolean bold = component.isBoldRaw();
+        if (bold != null && bold) {
+            BaseComponent duplicate = component.duplicate();
+            duplicate.setBold(null);
+
+            StyleNode styleNode = new StyleNode(parent, FormatStyle.BOLD);
+            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+            contentNode.notifyParent();
+
+            return List.of(styleNode);
+        }
+
+        Boolean italic = component.isItalicRaw();
+        if (italic != null && italic) {
+            BaseComponent duplicate = component.duplicate();
+            duplicate.setItalic(null);
+
+            StyleNode styleNode = new StyleNode(parent, FormatStyle.ITALICS);
+            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+            contentNode.notifyParent();
+
+            return List.of(styleNode);
+        }
+
+        Boolean underline = component.isUnderlinedRaw();
+        if (underline != null && underline) {
+            BaseComponent duplicate = component.duplicate();
+            duplicate.setUnderlined(null);
+
+            StyleNode styleNode = new StyleNode(parent, FormatStyle.UNDERLINE);
+            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+            contentNode.notifyParent();
+
+            return List.of(styleNode);
+        }
+
+        Boolean strikethrough = component.isStrikethroughRaw();
+        if (strikethrough != null && strikethrough) {
+            BaseComponent duplicate = component.duplicate();
+            duplicate.setStrikethrough(null);
+
+            StyleNode styleNode = new StyleNode(parent, FormatStyle.STRIKETHROUGH);
+            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+            contentNode.notifyParent();
+
+            return List.of(styleNode);
+        }
+
+        Boolean spoiler = component.isObfuscatedRaw();
+        if (spoiler != null && spoiler) {
+            BaseComponent duplicate = component.duplicate();
+            duplicate.setObfuscated(null);
+
+            StyleNode styleNode = new StyleNode(parent, FormatStyle.SPOILER);
+            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+            contentNode.notifyParent();
+
+            return List.of(styleNode);
+        }
+
+        ClickEvent clickEvent = component.getClickEvent();
+        if (clickEvent != null) {
+            BaseComponent duplicate = component.duplicate();
+            duplicate.setClickEvent(null);
+
+            ClickNode clickNode = new ClickNode(parent, clickEvent.getAction().name().toLowerCase(), clickEvent.getValue());
+            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(clickNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+            contentNode.notifyParent();
+
+            return List.of(clickNode);
+        }
+
+        HoverEvent hoverEvent = component.getHoverEvent();
+        if (hoverEvent != null) {
+            BaseComponent duplicate = component.duplicate();
+            duplicate.setHoverEvent(null);
+
+            List<Content> contentsRaw = hoverEvent.getContents();
+            JsonElement contents = null;
+
+            if (hoverEvent.getAction().equals(HoverEvent.Action.SHOW_TEXT)) {
+                JsonArray arr = new JsonArray();
+
+                for (Content content : contentsRaw) {
+                    Object value = ((Text) content).getValue();
+
+                    if (value instanceof BaseComponent comp) {
+                        FormatText<BaseComponent[]> contentText = parent.getFormatter().newText(new BaseComponent[]{comp}, Format.SPIGOT_COMPONENTS);
+
+                        arr.add(contentText.parse(Format.MINECRAFT_JSON));
+                    }
+
+                    if (value instanceof String str)
+                        arr.add(new JsonPrimitive(str));
+                }
+
+                contents = arr;
+            }
+
+            if (hoverEvent.getAction().equals(HoverEvent.Action.SHOW_ITEM)) {
+                JsonObject obj = new JsonObject();
+
+                Item item = ((Item) contentsRaw.get(0));
+
+                obj.addProperty("id", item.getId());
+
+                if (item.getCount() != -1)
+                    obj.addProperty("count", item.getCount());
+
+                if (item.getTag() != null)
+                    obj.addProperty("tag", item.getTag().getNbt());
+
+                contents = obj;
+            }
+
+            if (hoverEvent.getAction().equals(HoverEvent.Action.SHOW_ENTITY)) {
+                JsonObject obj = new JsonObject();
+
+                Entity entity = (Entity) contentsRaw.get(0);
+
+                obj.addProperty("type", entity.getType());
+                obj.addProperty("id", entity.getId());
+
+                if (entity.getName() != null) {
+                    FormatText<BaseComponent[]> name = parent.getFormatter().newText(new BaseComponent[]{entity.getName()}, Format.SPIGOT_COMPONENTS);
+                    obj.add("name", name.parse(Format.MINECRAFT_JSON));
+                }
+
+                contents = obj;
+            }
+
+            if (contents == null)
+                throw new AssertionError("Unsupported HoverAction type: " + hoverEvent.getAction());
+
+            HoverNode hoverNode = new HoverNode(parent, hoverEvent.getAction().name().toLowerCase(), contents);
+            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(hoverNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+            contentNode.notifyParent();
+
+            return List.of(hoverNode);
+        }
+
+        // CONTENT & CHILDREN
+
+        ArrayList<Node> nodes = new ArrayList<>();
+
+        if (component instanceof TextComponent tComp) {
+            String text = tComp.getText();
+            nodes.add(new TextNode(parent, text));
+        }
+
+        if (component.getExtra() != null) {
+            for (BaseComponent extra : component.getExtra()) {
+                UnresolvedNode<BaseComponent[]> node = new UnresolvedNode<>(parent, new BaseComponent[]{ extra }, Format.SPIGOT_COMPONENTS);
+                node.notifyParent();
+
+                nodes.add(node);
+            }
+        }
+
+        return nodes;
+    }
+}

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/SpigotComponentsBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/SpigotComponentsBuffer.java
@@ -2,6 +2,8 @@ package de.turtle_exception.fancyformat.buffers;
 
 import com.google.gson.*;
 import de.turtle_exception.fancyformat.*;
+import de.turtle_exception.fancyformat.formats.MinecraftJsonFormat;
+import de.turtle_exception.fancyformat.formats.SpigotComponentsFormat;
 import de.turtle_exception.fancyformat.nodes.*;
 import de.turtle_exception.fancyformat.styles.Color;
 import de.turtle_exception.fancyformat.styles.FormatStyle;
@@ -19,7 +21,7 @@ import java.util.function.Consumer;
 
 public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
     public SpigotComponentsBuffer(@NotNull Node parent, @NotNull BaseComponent[] raw) {
-        super(parent, raw, Format.SPIGOT_COMPONENTS);
+        super(parent, raw, SpigotComponentsFormat.get());
     }
 
     @Override
@@ -31,7 +33,7 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
             ArrayList<Node> nodes = new ArrayList<>();
 
             for (BaseComponent component : raw) {
-                UnresolvedNode<BaseComponent[]> node = new UnresolvedNode<>(parent, new BaseComponent[]{ component }, Format.SPIGOT_COMPONENTS);
+                UnresolvedNode<BaseComponent[]> node = new UnresolvedNode<>(parent, new BaseComponent[]{ component }, SpigotComponentsFormat.get());
                 node.notifyParent();
 
                 nodes.add(node);
@@ -51,7 +53,7 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
                 duplicate.setColor(null);
 
                 StyleNode styleNode = new StyleNode(parent, value);
-                UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+                UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, SpigotComponentsFormat.get());
                 contentNode.notifyParent();
 
                 return List.of(styleNode);
@@ -88,7 +90,7 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
             duplicate.setClickEvent(null);
 
             ClickNode clickNode = new ClickNode(parent, clickEvent.getAction().name().toLowerCase(), clickEvent.getValue());
-            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(clickNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(clickNode, new BaseComponent[]{ duplicate }, SpigotComponentsFormat.get());
             contentNode.notifyParent();
 
             return List.of(clickNode);
@@ -109,9 +111,9 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
                     Object value = ((Text) content).getValue();
 
                     if (value instanceof BaseComponent comp) {
-                        FormatText<BaseComponent[]> contentText = parent.getFormatter().newText(new BaseComponent[]{comp}, Format.SPIGOT_COMPONENTS);
+                        FormatText contentText = parent.getFormatter().fromFormat(new BaseComponent[]{ comp }, SpigotComponentsFormat.get());
 
-                        arr.add(contentText.parse(Format.MINECRAFT_JSON));
+                        arr.add(contentText.parse(MinecraftJsonFormat.get()));
                     }
 
                     if (value instanceof String str)
@@ -146,8 +148,8 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
                 obj.addProperty("id", entity.getId());
 
                 if (entity.getName() != null) {
-                    FormatText<BaseComponent[]> name = parent.getFormatter().newText(new BaseComponent[]{entity.getName()}, Format.SPIGOT_COMPONENTS);
-                    obj.add("name", name.parse(Format.MINECRAFT_JSON));
+                    FormatText name = parent.getFormatter().fromFormat(new BaseComponent[]{ entity.getName() }, SpigotComponentsFormat.get());
+                    obj.add("name", name.parse(MinecraftJsonFormat.get()));
                 }
 
                 contents = obj;
@@ -157,7 +159,7 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
                 throw new AssertionError("Unsupported HoverAction type: " + hoverEvent.getAction());
 
             HoverNode hoverNode = new HoverNode(parent, hoverEvent.getAction().name().toLowerCase(), contents);
-            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(hoverNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+            UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(hoverNode, new BaseComponent[]{ duplicate }, SpigotComponentsFormat.get());
             contentNode.notifyParent();
 
             return List.of(hoverNode);
@@ -174,7 +176,7 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
 
         if (component.getExtra() != null) {
             for (BaseComponent extra : component.getExtra()) {
-                UnresolvedNode<BaseComponent[]> node = new UnresolvedNode<>(parent, new BaseComponent[]{ extra }, Format.SPIGOT_COMPONENTS);
+                UnresolvedNode<BaseComponent[]> node = new UnresolvedNode<>(parent, new BaseComponent[]{ extra }, SpigotComponentsFormat.get());
                 node.notifyParent();
 
                 nodes.add(node);
@@ -189,7 +191,7 @@ public class SpigotComponentsBuffer extends Buffer<BaseComponent[]> {
         setter.accept(duplicate);
 
         StyleNode styleNode = new StyleNode(parent, style);
-        UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, Format.SPIGOT_COMPONENTS);
+        UnresolvedNode<BaseComponent[]> contentNode = new UnresolvedNode<>(styleNode, new BaseComponent[]{ duplicate }, SpigotComponentsFormat.get());
         contentNode.notifyParent();
 
         return List.of(styleNode);

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/TurtleBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/TurtleBuffer.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import de.turtle_exception.fancyformat.*;
+import de.turtle_exception.fancyformat.formats.TurtleFormat;
 import de.turtle_exception.fancyformat.nodes.*;
 import de.turtle_exception.fancyformat.styles.CodeBlock;
 import de.turtle_exception.fancyformat.styles.Color;
@@ -18,7 +19,7 @@ import java.util.concurrent.Callable;
 
 public class TurtleBuffer extends Buffer<JsonElement> {
     public TurtleBuffer(@NotNull Node parent, @NotNull JsonElement raw) {
-        super(parent, raw, Format.TURTLE);
+        super(parent, raw, TurtleFormat.get());
     }
 
     @Override
@@ -27,7 +28,7 @@ public class TurtleBuffer extends Buffer<JsonElement> {
             ArrayList<Node> nodes = new ArrayList<>();
 
             for (JsonElement element : arr) {
-                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(parent, element, Format.TURTLE);
+                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(parent, element, TurtleFormat.get());
                 node.notifyParent();
 
                 nodes.add(node);
@@ -107,7 +108,7 @@ public class TurtleBuffer extends Buffer<JsonElement> {
         JsonArray children = getOptional(() -> object.getAsJsonArray("children"));
         if (children != null) {
             for (JsonElement child : children) {
-                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(styleNode, child, Format.TURTLE);
+                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(styleNode, child, TurtleFormat.get());
                 node.notifyParent();
             }
         }

--- a/src/main/java/de/turtle_exception/fancyformat/buffers/TurtleBuffer.java
+++ b/src/main/java/de/turtle_exception/fancyformat/buffers/TurtleBuffer.java
@@ -16,20 +16,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-public class TurtleBuffer extends Buffer {
-    public TurtleBuffer(@NotNull Node parent, @NotNull String raw) {
-        super(parent, raw);
+public class TurtleBuffer extends Buffer<JsonElement> {
+    public TurtleBuffer(@NotNull Node parent, @NotNull JsonElement raw) {
+        super(parent, raw, Format.TURTLE);
     }
 
     @Override
     public @NotNull List<Node> parse() {
-        JsonElement json = getGson().fromJson(raw, JsonElement.class);
-
-        if (json instanceof JsonArray arr) {
+        if (raw instanceof JsonArray arr) {
             ArrayList<Node> nodes = new ArrayList<>();
 
             for (JsonElement element : arr) {
-                UnresolvedNode node = new UnresolvedNode(parent, element.toString(), Format.TURTLE);
+                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(parent, element, Format.TURTLE);
                 node.notifyParent();
 
                 nodes.add(node);
@@ -38,8 +36,8 @@ public class TurtleBuffer extends Buffer {
             return nodes;
         }
 
-        if (!(json instanceof JsonObject object))
-            throw new AssertionError("Cannot comprehend " + json.getClass().getSimpleName());
+        if (!(raw instanceof JsonObject object))
+            throw new AssertionError("Cannot comprehend " + raw.getClass().getSimpleName());
 
         String text = getOptional(() -> object.get("text").getAsString());
         if (text != null)
@@ -109,7 +107,7 @@ public class TurtleBuffer extends Buffer {
         JsonArray children = getOptional(() -> object.getAsJsonArray("children"));
         if (children != null) {
             for (JsonElement child : children) {
-                UnresolvedNode node = new UnresolvedNode(styleNode, child.toString(), Format.TURTLE);
+                UnresolvedNode<JsonElement> node = new UnresolvedNode<>(styleNode, child, Format.TURTLE);
                 node.notifyParent();
             }
         }

--- a/src/main/java/de/turtle_exception/fancyformat/builders/DiscordBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/DiscordBuilder.java
@@ -12,7 +12,7 @@ import de.turtle_exception.fancyformat.styles.Quote;
 import de.turtle_exception.fancyformat.styles.FormatStyle;
 import org.jetbrains.annotations.NotNull;
 
-public class DiscordBuilder extends MessageBuilder {
+public class DiscordBuilder extends MessageBuilder<String> {
     public DiscordBuilder(@NotNull Node node) {
         super(node);
     }

--- a/src/main/java/de/turtle_exception/fancyformat/builders/DiscordBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/DiscordBuilder.java
@@ -1,9 +1,9 @@
 package de.turtle_exception.fancyformat.builders;
 
-import de.turtle_exception.fancyformat.Format;
 import de.turtle_exception.fancyformat.MessageBuilder;
 import de.turtle_exception.fancyformat.Node;
 import de.turtle_exception.fancyformat.Style;
+import de.turtle_exception.fancyformat.formats.DiscordFormat;
 import de.turtle_exception.fancyformat.nodes.MentionNode;
 import de.turtle_exception.fancyformat.nodes.StyleNode;
 import de.turtle_exception.fancyformat.nodes.TextNode;
@@ -28,7 +28,7 @@ public class DiscordBuilder extends MessageBuilder<String> {
         StringBuilder builder = new StringBuilder();
 
         for (Node child : node.getChildren())
-            builder.append(child.toString(Format.DISCORD));
+            builder.append(child.toString(DiscordFormat.get()));
 
         if (node instanceof StyleNode sNode) {
             Style style = sNode.getStyle();

--- a/src/main/java/de/turtle_exception/fancyformat/builders/MinecraftJsonBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/MinecraftJsonBuilder.java
@@ -20,7 +20,7 @@ public class MinecraftJsonBuilder extends MessageBuilder<JsonElement> {
         if (node instanceof TextNode cNode)
             return new JsonPrimitive(cNode.getContent());
 
-        if (node instanceof RootNode rNode) {
+        if (node instanceof RootNode<?> rNode) {
             JsonArray arr = new JsonArray();
             for (Node child : rNode.getChildren())
                 arr.add(new MinecraftJsonBuilder(child).build());

--- a/src/main/java/de/turtle_exception/fancyformat/builders/MinecraftJsonBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/MinecraftJsonBuilder.java
@@ -11,24 +11,19 @@ import de.turtle_exception.fancyformat.styles.Quote;
 import de.turtle_exception.fancyformat.styles.VisualStyle;
 import org.jetbrains.annotations.NotNull;
 
-public class MinecraftJsonBuilder extends MessageBuilder {
+public class MinecraftJsonBuilder extends MessageBuilder<JsonElement> {
     public MinecraftJsonBuilder(@NotNull Node node) {
         super(node);
     }
 
-    @Override
-    public @NotNull String build() {
-        return getGson().toJson(this.buildJson());
-    }
-
-    public @NotNull JsonElement buildJson() {
+    public @NotNull JsonElement build() {
         if (node instanceof TextNode cNode)
             return new JsonPrimitive(cNode.getContent());
 
         if (node instanceof RootNode rNode) {
             JsonArray arr = new JsonArray();
             for (Node child : rNode.getChildren())
-                arr.add(new MinecraftJsonBuilder(child).buildJson());
+                arr.add(new MinecraftJsonBuilder(child).build());
             return arr;
         }
 
@@ -67,7 +62,7 @@ public class MinecraftJsonBuilder extends MessageBuilder {
 
         JsonArray extra = new JsonArray();
         for (Node child : node.getChildren())
-            extra.add(new MinecraftJsonBuilder(child).buildJson());
+            extra.add(new MinecraftJsonBuilder(child).build());
         json.add("extra", extra);
 
         return json;

--- a/src/main/java/de/turtle_exception/fancyformat/builders/MinecraftLegacyBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/MinecraftLegacyBuilder.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
-public class MinecraftLegacyBuilder extends MessageBuilder {
+public class MinecraftLegacyBuilder extends MessageBuilder<String> {
     private final String reset = node.getFormatter().getMinecraftFormattingCode() + "r";
 
     public MinecraftLegacyBuilder(@NotNull Node node) {

--- a/src/main/java/de/turtle_exception/fancyformat/builders/MinecraftLegacyBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/MinecraftLegacyBuilder.java
@@ -1,9 +1,9 @@
 package de.turtle_exception.fancyformat.builders;
 
-import de.turtle_exception.fancyformat.Format;
 import de.turtle_exception.fancyformat.MessageBuilder;
 import de.turtle_exception.fancyformat.Node;
 import de.turtle_exception.fancyformat.Style;
+import de.turtle_exception.fancyformat.formats.MinecraftLegacyFormat;
 import de.turtle_exception.fancyformat.nodes.MentionNode;
 import de.turtle_exception.fancyformat.nodes.StyleNode;
 import de.turtle_exception.fancyformat.nodes.TextNode;
@@ -54,7 +54,7 @@ public class MinecraftLegacyBuilder extends MessageBuilder<String> {
             }
 
             builder.append(prefix);
-            builder.append(child.toString(Format.MINECRAFT_LEGACY));
+            builder.append(child.toString(MinecraftLegacyFormat.get()));
 
             if (!prefix.isEmpty())
                 builder.append(reset);

--- a/src/main/java/de/turtle_exception/fancyformat/builders/PlaintextBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/PlaintextBuilder.java
@@ -6,7 +6,7 @@ import de.turtle_exception.fancyformat.Node;
 import de.turtle_exception.fancyformat.nodes.ContentNode;
 import org.jetbrains.annotations.NotNull;
 
-public class PlaintextBuilder extends MessageBuilder {
+public class PlaintextBuilder extends MessageBuilder<String> {
     public PlaintextBuilder(@NotNull Node node) {
         super(node);
     }

--- a/src/main/java/de/turtle_exception/fancyformat/builders/PlaintextBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/PlaintextBuilder.java
@@ -1,8 +1,8 @@
 package de.turtle_exception.fancyformat.builders;
 
-import de.turtle_exception.fancyformat.Format;
 import de.turtle_exception.fancyformat.MessageBuilder;
 import de.turtle_exception.fancyformat.Node;
+import de.turtle_exception.fancyformat.formats.PlaintextFormat;
 import de.turtle_exception.fancyformat.nodes.ContentNode;
 import org.jetbrains.annotations.NotNull;
 
@@ -19,7 +19,7 @@ public class PlaintextBuilder extends MessageBuilder<String> {
         StringBuilder builder = new StringBuilder();
 
         for (Node child : node.getChildren())
-            builder.append(child.toString(Format.PLAINTEXT));
+            builder.append(child.toString(PlaintextFormat.get()));
 
         return builder.toString();
     }

--- a/src/main/java/de/turtle_exception/fancyformat/builders/SpigotComponentsBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/SpigotComponentsBuilder.java
@@ -4,6 +4,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import de.turtle_exception.fancyformat.*;
+import de.turtle_exception.fancyformat.formats.MinecraftJsonFormat;
+import de.turtle_exception.fancyformat.formats.SpigotComponentsFormat;
 import de.turtle_exception.fancyformat.nodes.*;
 import de.turtle_exception.fancyformat.styles.Color;
 import de.turtle_exception.fancyformat.styles.FormatStyle;
@@ -44,8 +46,9 @@ public class SpigotComponentsBuilder extends MessageBuilder<BaseComponent[]> {
 
             if (hNode.getAction().equalsIgnoreCase("show_text")) {
                 // parse JSON content
-                FormatText<JsonElement> content = node.getFormatter().newText(contents, Format.MINECRAFT_JSON);
-                Text text = new Text(content.parse(Format.SPIGOT_COMPONENTS));
+                FormatText content = node.getFormatter().fromFormat(contents, MinecraftJsonFormat.get());
+                Text text = new Text(content.parse(SpigotComponentsFormat.get()));
+
 
                 event = new HoverEvent(HoverEvent.Action.SHOW_TEXT, text);
             } else if (hNode.getAction().equalsIgnoreCase("show_item")) {
@@ -79,8 +82,8 @@ public class SpigotComponentsBuilder extends MessageBuilder<BaseComponent[]> {
 
                 BaseComponent name = null;
                 if (obj.has("name")) {
-                    FormatText<JsonElement> content = node.getFormatter().newText(obj.get("name"), Format.MINECRAFT_JSON);
-                    name = new TextComponent(content.parse(Format.SPIGOT_COMPONENTS));
+                    FormatText content = node.getFormatter().fromFormat(obj.get("name"), MinecraftJsonFormat.get());
+                    name = new TextComponent(content.parse(SpigotComponentsFormat.get()));
                 }
 
                 Entity entity = new Entity(type, id, name);

--- a/src/main/java/de/turtle_exception/fancyformat/builders/SpigotComponentsBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/SpigotComponentsBuilder.java
@@ -1,0 +1,159 @@
+package de.turtle_exception.fancyformat.builders;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import de.turtle_exception.fancyformat.*;
+import de.turtle_exception.fancyformat.nodes.*;
+import de.turtle_exception.fancyformat.styles.Color;
+import de.turtle_exception.fancyformat.styles.FormatStyle;
+import de.turtle_exception.fancyformat.styles.Quote;
+import de.turtle_exception.fancyformat.styles.VisualStyle;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.*;
+import net.md_5.bungee.api.chat.hover.content.Entity;
+import net.md_5.bungee.api.chat.hover.content.Item;
+import net.md_5.bungee.api.chat.hover.content.Text;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class SpigotComponentsBuilder extends MessageBuilder<BaseComponent[]> {
+    public SpigotComponentsBuilder(@NotNull Node node) {
+        super(node);
+    }
+
+    @Override
+    public @NotNull BaseComponent @NotNull [] build() {
+        if (node instanceof TextNode tNode)
+            return new BaseComponent[]{ new TextComponent(tNode.getContent()) };
+
+        if (node instanceof RootNode<?> rNode) {
+            ArrayList<BaseComponent> list = new ArrayList<>();
+            for (Node child : rNode.getChildren())
+                list.addAll(Arrays.asList(new SpigotComponentsBuilder(child).build()));
+            return list.toArray(new BaseComponent[0]);
+        }
+
+        TextComponent component = new TextComponent();
+
+        if (node instanceof HoverNode hNode) {
+            JsonElement contents = hNode.getContents();
+            HoverEvent event = null;
+
+            if (hNode.getAction().equalsIgnoreCase("show_text")) {
+                // parse JSON content
+                FormatText<JsonElement> content = node.getFormatter().newText(contents, Format.MINECRAFT_JSON);
+                Text text = new Text(content.parse(Format.SPIGOT_COMPONENTS));
+
+                event = new HoverEvent(HoverEvent.Action.SHOW_TEXT, text);
+            } else if (hNode.getAction().equalsIgnoreCase("show_item")) {
+                JsonObject obj;
+                if (contents instanceof JsonArray arr)
+                    obj = arr.get(0).getAsJsonObject();
+                else
+                    obj = contents.getAsJsonObject();
+
+                String id = obj.get("id").getAsString();
+
+                int count = 1;
+                if (obj.has("count"))
+                    count = obj.get("count").getAsInt();
+
+                ItemTag tag = null;
+                if (obj.has("tag"))
+                    tag = ItemTag.ofNbt(obj.get("tag").getAsString());
+
+                Item item = new Item(id, count, tag);
+                event = new HoverEvent(HoverEvent.Action.SHOW_ITEM, item);
+            } else if (hNode.getAction().equalsIgnoreCase("show_entity")) {
+                JsonObject obj;
+                if (contents instanceof JsonArray arr)
+                    obj = arr.get(0).getAsJsonObject();
+                else
+                    obj = contents.getAsJsonObject();
+
+                String type = obj.get("type").getAsString();
+                String id   = obj.get("id").getAsString();
+
+                BaseComponent name = null;
+                if (obj.has("name")) {
+                    FormatText<JsonElement> content = node.getFormatter().newText(obj.get("name"), Format.MINECRAFT_JSON);
+                    name = new TextComponent(content.parse(Format.SPIGOT_COMPONENTS));
+                }
+
+                Entity entity = new Entity(type, id, name);
+                event = new HoverEvent(HoverEvent.Action.SHOW_ENTITY, entity);
+            }
+
+            component.setHoverEvent(event);
+        }
+
+        if (node instanceof ClickNode cNode) {
+            ClickEvent.Action action = null;
+            for (ClickEvent.Action value : ClickEvent.Action.values()) {
+                if (cNode.getAction().equalsIgnoreCase(value.name())) {
+                    action = value;
+                    break;
+                }
+            }
+
+            ClickEvent event = new ClickEvent(action, cNode.getValue());
+            component.setClickEvent(event);
+        }
+
+        if (node instanceof MentionNode) {
+            for (VisualStyle mentionStyle : node.getFormatter().getMentionStyles()) {
+                if (mentionStyle instanceof Color cStyle)
+                    component.setColor(ChatColor.getByChar(cStyle.getCode()));
+                if (mentionStyle instanceof FormatStyle fStyle)
+                    switch (fStyle.getName()) {
+                        case "bold": component.setBold(true);
+                        case "italic": component.setItalic(true);
+                        case "underline": component.setUnderlined(true);
+                        case "strikethrough": component.setStrikethrough(true);
+                        case "obfuscated": component.setObfuscated(true);
+                    }
+            }
+        }
+
+        if (node instanceof StyleNode sNode) {
+            Style style = sNode.getStyle();
+
+            if (style instanceof Color cStyle)
+                component.setColor(ChatColor.getByChar(cStyle.getCode()));
+
+            if (style instanceof FormatStyle fStyle)
+                switch (fStyle.getName()) {
+                    case "bold": component.setBold(true);
+                    case "italic": component.setItalic(true);
+                    case "underline": component.setUnderlined(true);
+                    case "strikethrough": component.setStrikethrough(true);
+                    case "obfuscated": component.setObfuscated(true);
+                }
+
+            if (style instanceof Quote) {
+                for (VisualStyle mentionStyle : node.getFormatter().getQuoteStyles()) {
+                    if (mentionStyle instanceof Color cStyle)
+                        component.setColor(ChatColor.getByChar(cStyle.getCode()));
+                    if (mentionStyle instanceof FormatStyle fStyle)
+                        switch (fStyle.getName()) {
+                            case "bold": component.setBold(true);
+                            case "italic": component.setItalic(true);
+                            case "underline": component.setUnderlined(true);
+                            case "strikethrough": component.setStrikethrough(true);
+                            case "obfuscated": component.setObfuscated(true);
+                        }
+                }
+            }
+        }
+
+        ArrayList<BaseComponent> extra = new ArrayList<>();
+        for (Node child : node.getChildren())
+            extra.addAll(Arrays.asList(new SpigotComponentsBuilder(child).build()));
+        component.setExtra(extra);
+
+        return new BaseComponent[]{ component };
+    }
+}

--- a/src/main/java/de/turtle_exception/fancyformat/builders/SpigotComponentsBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/SpigotComponentsBuilder.java
@@ -135,11 +135,11 @@ public class SpigotComponentsBuilder extends MessageBuilder<BaseComponent[]> {
 
         if (style instanceof FormatStyle fStyle)
             switch (fStyle.getName()) {
-                case "bold": component.setBold(true);
-                case "italic": component.setItalic(true);
-                case "underline": component.setUnderlined(true);
-                case "strikethrough": component.setStrikethrough(true);
-                case "obfuscated": component.setObfuscated(true);
+                case "bold"          -> component.setBold(true);
+                case "italic"        -> component.setItalic(true);
+                case "underline"     -> component.setUnderlined(true);
+                case "strikethrough" -> component.setStrikethrough(true);
+                case "obfuscated"    -> component.setObfuscated(true);
             }
     }
 }

--- a/src/main/java/de/turtle_exception/fancyformat/builders/SpigotComponentsBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/SpigotComponentsBuilder.java
@@ -104,49 +104,18 @@ public class SpigotComponentsBuilder extends MessageBuilder<BaseComponent[]> {
         }
 
         if (node instanceof MentionNode) {
-            for (VisualStyle mentionStyle : node.getFormatter().getMentionStyles()) {
-                if (mentionStyle instanceof Color cStyle)
-                    component.setColor(ChatColor.getByChar(cStyle.getCode()));
-                if (mentionStyle instanceof FormatStyle fStyle)
-                    switch (fStyle.getName()) {
-                        case "bold": component.setBold(true);
-                        case "italic": component.setItalic(true);
-                        case "underline": component.setUnderlined(true);
-                        case "strikethrough": component.setStrikethrough(true);
-                        case "obfuscated": component.setObfuscated(true);
-                    }
-            }
+            for (VisualStyle mentionStyle : node.getFormatter().getMentionStyles())
+                handleStyle(component, mentionStyle);
         }
 
         if (node instanceof StyleNode sNode) {
             Style style = sNode.getStyle();
 
-            if (style instanceof Color cStyle)
-                component.setColor(ChatColor.getByChar(cStyle.getCode()));
+            handleStyle(component, style);
 
-            if (style instanceof FormatStyle fStyle)
-                switch (fStyle.getName()) {
-                    case "bold": component.setBold(true);
-                    case "italic": component.setItalic(true);
-                    case "underline": component.setUnderlined(true);
-                    case "strikethrough": component.setStrikethrough(true);
-                    case "obfuscated": component.setObfuscated(true);
-                }
-
-            if (style instanceof Quote) {
-                for (VisualStyle mentionStyle : node.getFormatter().getQuoteStyles()) {
-                    if (mentionStyle instanceof Color cStyle)
-                        component.setColor(ChatColor.getByChar(cStyle.getCode()));
-                    if (mentionStyle instanceof FormatStyle fStyle)
-                        switch (fStyle.getName()) {
-                            case "bold": component.setBold(true);
-                            case "italic": component.setItalic(true);
-                            case "underline": component.setUnderlined(true);
-                            case "strikethrough": component.setStrikethrough(true);
-                            case "obfuscated": component.setObfuscated(true);
-                        }
-                }
-            }
+            if (style instanceof Quote)
+                for (VisualStyle mentionStyle : node.getFormatter().getQuoteStyles())
+                    handleStyle(component, mentionStyle);
         }
 
         ArrayList<BaseComponent> extra = new ArrayList<>();
@@ -155,5 +124,19 @@ public class SpigotComponentsBuilder extends MessageBuilder<BaseComponent[]> {
         component.setExtra(extra);
 
         return new BaseComponent[]{ component };
+    }
+
+    private static void handleStyle(@NotNull BaseComponent component, @NotNull Style style) {
+        if (style instanceof Color cStyle)
+            component.setColor(ChatColor.getByChar(cStyle.getCode()));
+
+        if (style instanceof FormatStyle fStyle)
+            switch (fStyle.getName()) {
+                case "bold": component.setBold(true);
+                case "italic": component.setItalic(true);
+                case "underline": component.setUnderlined(true);
+                case "strikethrough": component.setStrikethrough(true);
+                case "obfuscated": component.setObfuscated(true);
+            }
     }
 }

--- a/src/main/java/de/turtle_exception/fancyformat/builders/TurtleBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/TurtleBuilder.java
@@ -24,7 +24,7 @@ public class TurtleBuilder extends MessageBuilder<JsonElement> {
     }
 
     public @NotNull JsonElement build() {
-        if (node instanceof RootNode rNode) {
+        if (node instanceof RootNode<?> rNode) {
             JsonArray arr = new JsonArray();
             for (Node child : rNode.getChildren())
                 arr.add(new TurtleBuilder(child).build());

--- a/src/main/java/de/turtle_exception/fancyformat/builders/TurtleBuilder.java
+++ b/src/main/java/de/turtle_exception/fancyformat/builders/TurtleBuilder.java
@@ -18,21 +18,16 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
-public class TurtleBuilder extends MessageBuilder {
+public class TurtleBuilder extends MessageBuilder<JsonElement> {
     public TurtleBuilder(@NotNull Node node) {
         super(node);
     }
 
-    @Override
-    public @NotNull String build() {
-        return getGson().toJson(this.buildJson());
-    }
-
-    public @NotNull JsonElement buildJson() {
+    public @NotNull JsonElement build() {
         if (node instanceof RootNode rNode) {
             JsonArray arr = new JsonArray();
             for (Node child : rNode.getChildren())
-                arr.add(new TurtleBuilder(child).buildJson());
+                arr.add(new TurtleBuilder(child).build());
             return arr;
         }
 
@@ -70,7 +65,7 @@ public class TurtleBuilder extends MessageBuilder {
         if (!children.isEmpty()) {
             JsonArray childArr = new JsonArray();
             for (Node child : children)
-                childArr.add(new TurtleBuilder(child).buildJson());
+                childArr.add(new TurtleBuilder(child).build());
             json.add("children", childArr);
         }
 

--- a/src/main/java/de/turtle_exception/fancyformat/formats/DiscordFormat.java
+++ b/src/main/java/de/turtle_exception/fancyformat/formats/DiscordFormat.java
@@ -1,0 +1,18 @@
+package de.turtle_exception.fancyformat.formats;
+
+import de.turtle_exception.fancyformat.Format;
+import de.turtle_exception.fancyformat.buffers.DiscordBuffer;
+import de.turtle_exception.fancyformat.builders.DiscordBuilder;
+import org.jetbrains.annotations.NotNull;
+
+public class DiscordFormat extends Format<String> {
+    private static final DiscordFormat INSTANCE = new DiscordFormat();
+
+    public DiscordFormat() {
+        super("DISCORD", String.class, DiscordBuffer::new, DiscordBuilder::new, s -> s, s -> s);
+    }
+
+    public static @NotNull DiscordFormat get() {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/de/turtle_exception/fancyformat/formats/MinecraftJsonFormat.java
+++ b/src/main/java/de/turtle_exception/fancyformat/formats/MinecraftJsonFormat.java
@@ -1,0 +1,24 @@
+package de.turtle_exception.fancyformat.formats;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import de.turtle_exception.fancyformat.Format;
+import de.turtle_exception.fancyformat.buffers.MinecraftJsonBuffer;
+import de.turtle_exception.fancyformat.builders.MinecraftJsonBuilder;
+import org.jetbrains.annotations.NotNull;
+
+public class MinecraftJsonFormat extends Format<JsonElement> {
+    private static final MinecraftJsonFormat INSTANCE = new MinecraftJsonFormat();
+
+    private static final Gson gson = new GsonBuilder()
+            .create();
+
+    private MinecraftJsonFormat() {
+        super("MINECRAFT_JSON", JsonElement.class, MinecraftJsonBuffer::new, MinecraftJsonBuilder::new, s -> gson.fromJson(s, JsonElement.class), JsonElement::toString);
+    }
+
+    public static @NotNull MinecraftJsonFormat get() {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/de/turtle_exception/fancyformat/formats/MinecraftLegacyFormat.java
+++ b/src/main/java/de/turtle_exception/fancyformat/formats/MinecraftLegacyFormat.java
@@ -1,0 +1,18 @@
+package de.turtle_exception.fancyformat.formats;
+
+import de.turtle_exception.fancyformat.Format;
+import de.turtle_exception.fancyformat.buffers.MinecraftLegacyBuffer;
+import de.turtle_exception.fancyformat.builders.MinecraftLegacyBuilder;
+import org.jetbrains.annotations.NotNull;
+
+public class MinecraftLegacyFormat extends Format<String> {
+    private static final MinecraftLegacyFormat INSTANCE = new MinecraftLegacyFormat();
+
+    public MinecraftLegacyFormat() {
+        super("MINECRAFT_LEGACY", String.class, MinecraftLegacyBuffer::new, MinecraftLegacyBuilder::new, s -> s, s -> s);
+    }
+
+    public static @NotNull MinecraftLegacyFormat get() {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/de/turtle_exception/fancyformat/formats/PlaintextFormat.java
+++ b/src/main/java/de/turtle_exception/fancyformat/formats/PlaintextFormat.java
@@ -1,0 +1,18 @@
+package de.turtle_exception.fancyformat.formats;
+
+import de.turtle_exception.fancyformat.Format;
+import de.turtle_exception.fancyformat.buffers.PlaintextBuffer;
+import de.turtle_exception.fancyformat.builders.PlaintextBuilder;
+import org.jetbrains.annotations.NotNull;
+
+public class PlaintextFormat extends Format<String> {
+    private static final PlaintextFormat INSTANCE = new PlaintextFormat();
+
+    public PlaintextFormat() {
+        super("PLAINTEXT", String.class, PlaintextBuffer::new, PlaintextBuilder::new, s -> s, s -> s);
+    }
+
+    public static @NotNull PlaintextFormat get() {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/de/turtle_exception/fancyformat/formats/SpigotComponentsFormat.java
+++ b/src/main/java/de/turtle_exception/fancyformat/formats/SpigotComponentsFormat.java
@@ -1,0 +1,19 @@
+package de.turtle_exception.fancyformat.formats;
+
+import de.turtle_exception.fancyformat.Format;
+import de.turtle_exception.fancyformat.buffers.SpigotComponentsBuffer;
+import de.turtle_exception.fancyformat.builders.SpigotComponentsBuilder;
+import net.md_5.bungee.api.chat.BaseComponent;
+import org.jetbrains.annotations.NotNull;
+
+public class SpigotComponentsFormat extends Format<BaseComponent[]> {
+    private static final SpigotComponentsFormat INSTANCE = new SpigotComponentsFormat();
+
+    private SpigotComponentsFormat() {
+        super("SPIGOT_COMPONENTS", BaseComponent[].class, SpigotComponentsBuffer::new, SpigotComponentsBuilder::new);
+    }
+
+    public static @NotNull SpigotComponentsFormat get() {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/de/turtle_exception/fancyformat/formats/TurtleFormat.java
+++ b/src/main/java/de/turtle_exception/fancyformat/formats/TurtleFormat.java
@@ -1,0 +1,24 @@
+package de.turtle_exception.fancyformat.formats;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import de.turtle_exception.fancyformat.Format;
+import de.turtle_exception.fancyformat.buffers.TurtleBuffer;
+import de.turtle_exception.fancyformat.builders.TurtleBuilder;
+import org.jetbrains.annotations.NotNull;
+
+public class TurtleFormat extends Format<JsonElement> {
+    private static final TurtleFormat INSTANCE = new TurtleFormat();
+
+    private static final Gson gson = new GsonBuilder()
+            .create();
+
+    private TurtleFormat() {
+        super("TURTLE", JsonElement.class, TurtleBuffer::new, TurtleBuilder::new, s -> gson.fromJson(s, JsonElement.class), JsonElement::toString);
+    }
+
+    public static @NotNull TurtleFormat get() {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/de/turtle_exception/fancyformat/nodes/HoverNode.java
+++ b/src/main/java/de/turtle_exception/fancyformat/nodes/HoverNode.java
@@ -1,6 +1,6 @@
 package de.turtle_exception.fancyformat.nodes;
 
-import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import de.turtle_exception.fancyformat.FancyFormatter;
 import de.turtle_exception.fancyformat.Node;
@@ -8,18 +8,18 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class HoverNode extends ActionNode {
-    protected final @NotNull JsonArray contents;
+    protected final @NotNull JsonElement contents;
 
-    public HoverNode(@NotNull FancyFormatter formatter, @Nullable Node parent, @NotNull String action, @NotNull JsonArray contents) {
+    public HoverNode(@NotNull FancyFormatter formatter, @Nullable Node parent, @NotNull String action, @NotNull JsonElement contents) {
         super(formatter, parent, action);
         this.contents = contents;
     }
 
-    public HoverNode(@NotNull Node parent, @NotNull String action, @NotNull JsonArray contents) {
+    public HoverNode(@NotNull Node parent, @NotNull String action, @NotNull JsonElement contents) {
         this(parent.getFormatter(), parent, action, contents);
     }
 
-    public @NotNull JsonArray getContents() {
+    public @NotNull JsonElement getContents() {
         return contents;
     }
 

--- a/src/main/java/de/turtle_exception/fancyformat/nodes/RootNode.java
+++ b/src/main/java/de/turtle_exception/fancyformat/nodes/RootNode.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 
 /** An empty node that functions as a container to hold one or more children. */
 public class RootNode extends Node {
-    public RootNode(@NotNull FancyFormatter formatter, @NotNull String raw, @NotNull Format format) {
+    public RootNode(@NotNull FancyFormatter formatter, @NotNull String raw, @NotNull Format<?> format) {
         super(formatter, null);
 
         this.children.add(new UnresolvedNode(this, raw, format));

--- a/src/main/java/de/turtle_exception/fancyformat/nodes/RootNode.java
+++ b/src/main/java/de/turtle_exception/fancyformat/nodes/RootNode.java
@@ -10,6 +10,6 @@ public class RootNode<T> extends Node {
     public RootNode(@NotNull FancyFormatter formatter, @NotNull T raw, @NotNull Format<T> format) {
         super(formatter, null);
 
-        this.children.add(new UnresolvedNode(this, raw, format));
+        this.children.add(new UnresolvedNode<>(this, raw, format));
     }
 }

--- a/src/main/java/de/turtle_exception/fancyformat/nodes/RootNode.java
+++ b/src/main/java/de/turtle_exception/fancyformat/nodes/RootNode.java
@@ -6,8 +6,8 @@ import de.turtle_exception.fancyformat.Node;
 import org.jetbrains.annotations.NotNull;
 
 /** An empty node that functions as a container to hold one or more children. */
-public class RootNode extends Node {
-    public RootNode(@NotNull FancyFormatter formatter, @NotNull String raw, @NotNull Format<?> format) {
+public class RootNode<T> extends Node {
+    public RootNode(@NotNull FancyFormatter formatter, @NotNull T raw, @NotNull Format<T> format) {
         super(formatter, null);
 
         this.children.add(new UnresolvedNode(this, raw, format));

--- a/src/main/java/de/turtle_exception/fancyformat/nodes/UnresolvedNode.java
+++ b/src/main/java/de/turtle_exception/fancyformat/nodes/UnresolvedNode.java
@@ -52,18 +52,16 @@ public class UnresolvedNode<T> extends Node {
             // remove self
             siblings.remove(i);
 
-            // add new siblings in reverse (because of right-shift insert)
-            int j = nodes.size();
-            while (j--> 0)
-                siblings.add(i, nodes.get(j));
-
             break;
         }
 
         // resolve children of new siblings
         int i = nodes.size();
-        for (Node node : nodes)
+        for (Node node : nodes) {
+            if (!(node instanceof UnresolvedNode<?>))
+                siblings.add(node);
             i += node.resolve();
+        }
         return i;
     }
 }

--- a/src/main/java/de/turtle_exception/fancyformat/nodes/UnresolvedNode.java
+++ b/src/main/java/de/turtle_exception/fancyformat/nodes/UnresolvedNode.java
@@ -36,7 +36,7 @@ public class UnresolvedNode<T> extends Node {
 
                 // replace self
                 siblings.remove(i);
-                siblings.add(i, new TextNode(parent, format.getMutatorObjectToString().apply(raw)));
+                siblings.add(i, new TextNode(parent, format.makeString(raw)));
 
                 return 1;
             }

--- a/src/main/java/de/turtle_exception/fancyformat/nodes/UnresolvedNode.java
+++ b/src/main/java/de/turtle_exception/fancyformat/nodes/UnresolvedNode.java
@@ -13,9 +13,9 @@ import java.util.List;
 public class UnresolvedNode extends Node {
     protected final @NotNull Node parent;
     protected final @NotNull String raw;
-    protected final @NotNull Format format;
+    protected final @NotNull Format<?> format;
 
-    public UnresolvedNode(@NotNull Node parent, @NotNull String raw, @NotNull Format format) {
+    public UnresolvedNode(@NotNull Node parent, @NotNull String raw, @NotNull Format<?> format) {
         super(parent.getFormatter(), parent);
         this.parent = parent;
         this.raw = raw;

--- a/src/main/java/de/turtle_exception/fancyformat/nodes/UnresolvedNode.java
+++ b/src/main/java/de/turtle_exception/fancyformat/nodes/UnresolvedNode.java
@@ -10,12 +10,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 /** A node that has not yet been processed. Resolving this node may produce one or more nodes. */
-public class UnresolvedNode extends Node {
+public class UnresolvedNode<T> extends Node {
     protected final @NotNull Node parent;
-    protected final @NotNull String raw;
-    protected final @NotNull Format<?> format;
+    protected final @NotNull T raw;
+    protected final @NotNull Format<T> format;
 
-    public UnresolvedNode(@NotNull Node parent, @NotNull String raw, @NotNull Format<?> format) {
+    public UnresolvedNode(@NotNull Node parent, @NotNull T raw, @NotNull Format<T> format) {
         super(parent.getFormatter(), parent);
         this.parent = parent;
         this.raw = raw;
@@ -36,13 +36,13 @@ public class UnresolvedNode extends Node {
 
                 // replace self
                 siblings.remove(i);
-                siblings.add(i, new TextNode(parent, raw));
+                siblings.add(i, new TextNode(parent, format.getMutatorObjectToString().apply(raw)));
 
                 return 1;
             }
         }
 
-        Buffer buffer = format.newBuffer(parent, raw);
+        Buffer<T> buffer = format.newBuffer(parent, raw);
         List<Node> nodes = buffer.parse();
 
         ArrayList<Node> siblings = parent.getChildren();


### PR DESCRIPTION
Since serialization & deserialization of Minecraft JSON text is not fully supported by spigot's API (e.g. Unable to parse `TextComponent`s without a _text_ tag), this library should optionally support parsing a FormatText directly to `BaseComponent`s.

The implementation proposed by this pr is not flawless. Currently, all formats that are nested in a JSON-style don't allow multiple attributes to be parsed into one element. This should be fixed regardless of this specific feature, so for now the implementation follows the example set by other formats.